### PR TITLE
Guard update/remove against empty filters

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1,5 +1,5 @@
 import { prepare, prepareId } from './prepare.js';
-import { is } from './utils.js';
+import { is, isNonEmptyFilter } from './utils.js';
 
 /**
  * Wrapper around a single MongoDB collection. Public methods are fail-silent:
@@ -213,11 +213,25 @@ export class Collection {
   /**
    * Update many documents matching the query.
    *
+   * The query must be a non-empty plain object. `null`, `undefined`, and `{}`
+   * are rejected to prevent accidentally rewriting every document in the
+   * collection (for example when a caller forgets to populate a filter
+   * variable).
+   *
    * @param {object} query
    * @param {object} update - Mongo update operators (e.g. {$set: {...}})
    * @returns {Promise<boolean>} True if at least one document was modified
    */
   async update(query, update) {
+    if (!isNonEmptyFilter(query)) {
+      this.client.emit(new Error('empty filter rejected'), {
+        method: 'update',
+        collection: this.name,
+        query
+      });
+      return false;
+    }
+
     try {
       const col = await this.client.open(this.name);
       const result = await col.updateMany(prepare(query), update);
@@ -232,10 +246,22 @@ export class Collection {
   /**
    * Delete many documents matching the query.
    *
+   * The query must be a non-empty plain object. `null`, `undefined`, and `{}`
+   * are rejected to prevent accidentally wiping the collection.
+   *
    * @param {object} query
    * @returns {Promise<boolean>} True if at least one document was deleted
    */
   async remove(query) {
+    if (!isNonEmptyFilter(query)) {
+      this.client.emit(new Error('empty filter rejected'), {
+        method: 'remove',
+        collection: this.name,
+        query
+      });
+      return false;
+    }
+
     try {
       const col = await this.client.open(this.name);
       const result = await col.deleteMany(prepare(query));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,3 +7,15 @@ const obj = (o) =>
   Object.getPrototypeOf(o) === Object.prototype;
 
 export const is = { fun, str, arr, obj };
+
+/**
+ * True when `q` is a plain object with at least one own enumerable key. Used by
+ * `update` and `remove` to reject empty/missing filters that would otherwise
+ * hit every document in the collection.
+ *
+ * @param {unknown} q
+ * @returns {boolean}
+ */
+export function isNonEmptyFilter(q) {
+  return is.obj(q) && Object.keys(q).length > 0;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easymongo",
-  "version": "6.0.1",
+  "version": "6.0.0",
   "description": "Thin, opinionated wrapper around the MongoDB Node.js driver with a fail-silent promise API.",
   "keywords": [
     "easymongo",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easymongo",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Thin, opinionated wrapper around the MongoDB Node.js driver with a fail-silent promise API.",
   "keywords": [
     "easymongo",

--- a/readme.md
+++ b/readme.md
@@ -140,6 +140,17 @@ The `ctx` passed to `onError` has the shape `{ method, collection?, query? }`, e
 
 A throwing `onError` is itself caught and ignored; a broken reporter cannot take down the caller.
 
+## Empty filter protection
+
+`update(query, $update)` and `remove(query)` reject empty filters. `null`, `undefined`, and `{}` short-circuit to `false` without touching the driver. The rejection is reported through `onError` (or `console.error`) with `{ method, collection, query }` so it stays visible.
+
+```js
+await users.update(maybeMissing, { $set: { url: 'x' } }); // false, nothing rewritten
+await users.remove(undefined); // false, nothing deleted
+```
+
+To wipe a collection, use a non-empty filter such as `{ _id: { $exists: true } }`, or call the native driver directly via `client.open(name)`.
+
 ## Author
 
 - [Alexey Simonenko](https://github.com/meritt)

--- a/test/index.js
+++ b/test/index.js
@@ -10,17 +10,24 @@ const COLLECTION = `easymongo_test_${randomUUID()}`;
 const mongo = new MongoClient({ dbname: 'test' }, { silent: true });
 const users = mongo.collection(COLLECTION);
 
+// Fixture cleanup goes through the native driver: `update({})`/`remove({})`
+// are blocked by the empty-filter guard.
+async function wipe(client, name) {
+  const native = await client.open(name);
+  await native.deleteMany({});
+}
+
 before(async () => {
-  await users.remove({});
+  await wipe(mongo, COLLECTION);
 });
 
 after(async () => {
-  await users.remove({});
+  await wipe(mongo, COLLECTION);
   await mongo.close();
 });
 
 beforeEach(async () => {
-  await users.remove({});
+  await wipe(mongo, COLLECTION);
 });
 
 describe('count', () => {
@@ -221,6 +228,121 @@ describe('removeById', () => {
   });
 });
 
+describe('empty filter guard', () => {
+  test('update(null) returns false and does not modify collection', async () => {
+    await users.saveAll([{ name: 'A' }, { name: 'B' }]);
+    const result = await users.update(null, { $set: { url: 'x' } });
+    assert.equal(result, false);
+    const all = await users.find();
+    assert.equal(all.length, 2);
+    for (const doc of all) {
+      assert.equal(doc.url, undefined);
+    }
+  });
+
+  test('update(undefined) returns false and does not modify', async () => {
+    await users.save({ name: 'A' });
+    const result = await users.update(undefined, { $set: { url: 'x' } });
+    assert.equal(result, false);
+    const doc = await users.findOne({ name: 'A' });
+    assert.equal(doc.url, undefined);
+  });
+
+  test('update({}) returns false and does not modify', async () => {
+    await users.save({ name: 'A' });
+    const result = await users.update({}, { $set: { url: 'x' } });
+    assert.equal(result, false);
+    const doc = await users.findOne({ name: 'A' });
+    assert.equal(doc.url, undefined);
+  });
+
+  test('update with explicit query still works (control)', async () => {
+    await users.save({ name: 'A' });
+    const ok = await users.update({ name: 'A' }, { $set: { url: 'x' } });
+    assert.equal(ok, true);
+    const doc = await users.findOne({ name: 'A' });
+    assert.equal(doc.url, 'x');
+  });
+
+  test('remove(null) returns false and does not delete', async () => {
+    await users.saveAll([{ name: 'A' }, { name: 'B' }]);
+    assert.equal(await users.remove(null), false);
+    assert.equal(await users.count(), 2);
+  });
+
+  test('remove(undefined) returns false and does not delete', async () => {
+    await users.save({ name: 'A' });
+    assert.equal(await users.remove(undefined), false);
+    assert.equal(await users.count(), 1);
+  });
+
+  test('remove({}) returns false and does not delete', async () => {
+    await users.save({ name: 'A' });
+    assert.equal(await users.remove({}), false);
+    assert.equal(await users.count(), 1);
+  });
+
+  test('remove with explicit query still works (control)', async () => {
+    await users.saveAll([{ name: 'A' }, { name: 'B' }]);
+    assert.equal(await users.remove({ name: 'A' }), true);
+    assert.equal(await users.count(), 1);
+  });
+
+  test('onError receives ctx for blocked update', async () => {
+    const captured = [];
+    const local = new MongoClient(
+      { dbname: 'test' },
+      { onError: (err, ctx) => captured.push({ err, ctx }) }
+    );
+    const localUsers = local.collection(COLLECTION);
+
+    await localUsers.update(null, { $set: { x: 1 } });
+
+    assert.equal(captured.length, 1);
+    assert.equal(captured[0].ctx.method, 'update');
+    assert.equal(captured[0].ctx.collection, COLLECTION);
+    assert.match(captured[0].err.message, /empty filter/i);
+
+    await local.close();
+  });
+
+  test('onError receives ctx for blocked remove', async () => {
+    const captured = [];
+    const local = new MongoClient(
+      { dbname: 'test' },
+      { onError: (err, ctx) => captured.push({ err, ctx }) }
+    );
+    const localUsers = local.collection(COLLECTION);
+
+    await localUsers.remove({});
+
+    assert.equal(captured.length, 1);
+    assert.equal(captured[0].ctx.method, 'remove');
+    assert.equal(captured[0].ctx.collection, COLLECTION);
+    assert.match(captured[0].err.message, /empty filter/i);
+
+    await local.close();
+  });
+
+  test('silent: true suppresses guard report', async () => {
+    const captured = [];
+    const local = new MongoClient(
+      { dbname: 'test' },
+      {
+        silent: true,
+        onError: (err, ctx) => captured.push({ err, ctx })
+      }
+    );
+    const localUsers = local.collection(COLLECTION);
+
+    const ok = await localUsers.remove(null);
+    assert.equal(ok, false);
+    assert.equal(captured.length, 0);
+
+    await local.close();
+  });
+});
+
 describe('query preparation', () => {
   test('id alias: query with {id: ...} works', async () => {
     const created = await users.save({ name: 'Alexey' });
@@ -324,7 +446,7 @@ describe('connection lifecycle', () => {
     assert.ok(found);
     assert.equal(found.name, 'before');
 
-    await col.remove({});
+    await wipe(client, col.name);
     await client.close();
   });
 });

--- a/test/observability.js
+++ b/test/observability.js
@@ -44,14 +44,16 @@ test('fail-silent: save returns null on bad connection', async () => {
 
 test('fail-silent: update returns false on bad connection', async () => {
   const mongo = new MongoClient(UNREACHABLE, { silent: true });
-  const result = await mongo.collection('users').update({}, { $set: { a: 1 } });
+  const result = await mongo
+    .collection('users')
+    .update({ name: 'x' }, { $set: { a: 1 } });
   assert.equal(result, false);
   await mongo.close();
 });
 
 test('fail-silent: remove returns false on bad connection', async () => {
   const mongo = new MongoClient(UNREACHABLE, { silent: true });
-  const result = await mongo.collection('users').remove({});
+  const result = await mongo.collection('users').remove({ name: 'x' });
   assert.equal(result, false);
   await mongo.close();
 });


### PR DESCRIPTION
## Summary

`prepare(null)` and `prepare(undefined)` collapse to `{}` and previously flowed straight into `updateMany` / `deleteMany` — a missing filter variable would silently rewrite or wipe the whole collection. In a fail-silent API that is a real data-corruption path. v6.0.0 introduced the regression; this PR closes it.

`update(query, $update)` and `remove(query)` now reject `null`, `undefined`, and `{}` before they reach the driver. The rejection short-circuits to `false` and is reported through the standard `emit` hook with `{ method, collection, query }` so it stays visible without breaking the fail-silent contract.

- New `isNonEmptyFilter(q)` in `lib/utils.js` (shallow plain-object check, no recursion — `{ a: undefined }` is treated as a real filter).
- `removeById(null)` is unaffected: `prepareId(null)` yields a fresh `ObjectId` that matches nothing.
- Test fixture cleanup (`before`/`after`/`beforeEach` in `test/index.js`) now goes through the native driver via `client.open(name).then(c => c.deleteMany({}))` because `users.remove({})` is intentionally blocked.
- New "Empty filter protection" section in `readme.md`.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm test` — 114 tests, including 11 new ones in the `empty filter guard` suite (null / undefined / {} for both methods, control cases, `onError` ctx, `silent: true`)
- [x] `pnpm pack --dry-run` — tarball still contains only `lib/`, `package.json`, `readme.md`, `LICENSE`