### PR TITLE
Add Symbol.asyncDispose to MongoClient

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -113,6 +113,16 @@ export class MongoClient {
   }
 
   /**
+   * Close the underlying connection when used with `await using`. Mirrors
+   * `close()`; safe to call multiple times.
+   *
+   * @returns {Promise<void>}
+   */
+  async [Symbol.asyncDispose]() {
+    await this.close();
+  }
+
+  /**
    * Close the underlying connection and clear cached state. Safe to call
    * multiple times.
    *

--- a/test/dispose.js
+++ b/test/dispose.js
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { test } from 'node:test';
+
+import { MongoClient } from '../lib/index.js';
+
+test('Symbol.asyncDispose closes the active connection', async () => {
+  const mongo = new MongoClient({ dbname: 'test' }, { silent: true });
+  await mongo.collection(`easymongo_dispose_${randomUUID()}`).count();
+
+  assert.notEqual(mongo.client, null);
+  await mongo[Symbol.asyncDispose]();
+  assert.equal(mongo.client, null);
+  assert.equal(mongo.db, null);
+});
+
+test('Symbol.asyncDispose is idempotent on never-opened client', async () => {
+  const mongo = new MongoClient({ dbname: 'test' }, { silent: true });
+  await mongo[Symbol.asyncDispose]();
+  await mongo[Symbol.asyncDispose]();
+  assert.equal(mongo.client, null);
+});
+
+test('await using triggers close at scope end', async () => {
+  const collection = `easymongo_dispose_${randomUUID()}`;
+  let captured;
+
+  {
+    await using mongo = new MongoClient({ dbname: 'test' }, { silent: true });
+    await mongo.collection(collection).save({ name: 'A' });
+    captured = mongo;
+    assert.notEqual(mongo.client, null);
+  }
+
+  assert.equal(captured.client, null);
+  assert.equal(captured.db, null);
+
+  // Cleanup leftover document via a fresh client.
+  const cleaner = new MongoClient({ dbname: 'test' }, { silent: true });
+  const native = await cleaner.open(collection);
+  await native.deleteMany({});
+  await cleaner.close();
+});


### PR DESCRIPTION
## Summary

- `MongoClient.prototype[Symbol.asyncDispose]` calls `close()`.
- Enables `await using client = new MongoClient(url)` — the connection closes automatically at scope end.
- Idempotent: safe on already-closed or never-opened clients (mirrors existing `close()` semantics).

Pure addition. No public method changes shape.

## Test plan
- [x] `pnpm test` — all 118 tests pass (3 new in `test/dispose.js`).
- [x] `pnpm lint` — clean.
- [x] `pnpm format:check` — clean.
- [x] CI matrix: Node 24/25 × Mongo 7.0/8.0/8.2.

## Context

Part of the yamb wishlist landing — see `plan/yamb-architecture-decisions.md` on `feature/yamb-request`. Aligns with Node 24 LTS `await using` pattern.