### PR TITLE
Add AbortSignal support to all async Collection methods

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -82,12 +82,16 @@ export class Collection {
    * Check whether at least one document matches the query.
    *
    * @param {object} [query]
+   * @param {object} [options] - { signal? }
    * @returns {Promise<boolean>}
    */
-  async exists(query) {
+  async exists(query, options) {
     try {
       const col = await this.client.open(this.name);
-      const doc = await col.findOne(prepare(query), { projection: { _id: 1 } });
+      const doc = await col.findOne(
+        prepare(query),
+        withSignal({ projection: { _id: 1 } }, options)
+      );
 
       return doc != null;
     } catch (err) {
@@ -107,17 +111,25 @@ export class Collection {
    * collection cannot OOM before the outer catch can recover.
    *
    * @param {object} [query]
+   * @param {object} [options] - { signal? }
    * @returns {Promise<number>}
    */
-  async count(query) {
+  async count(query, options) {
     try {
       const col = await this.client.open(this.name);
       const prepared = prepare(query);
+      const signal = signalOf(options);
 
       try {
-        return await col.countDocuments(prepared);
+        return await col.countDocuments(
+          prepared,
+          signal ? { signal } : undefined
+        );
       } catch {
-        const cursor = col.find(prepared, { projection: { _id: 1 } });
+        const cursorOpts = signal
+          ? { projection: { _id: 1 }, signal }
+          : { projection: { _id: 1 } };
+        const cursor = col.find(prepared, cursorOpts);
         let n = 0;
         try {
           for await (const _doc of cursor) {
@@ -139,12 +151,18 @@ export class Collection {
    *
    * @param {string} field
    * @param {object} [query]
+   * @param {object} [options] - { signal? }
    * @returns {Promise<unknown[]>}
    */
-  async distinct(field, query) {
+  async distinct(field, query, options) {
     try {
       const col = await this.client.open(this.name);
-      const result = await col.distinct(field, prepare(query));
+      const signal = signalOf(options);
+      const result = await col.distinct(
+        field,
+        prepare(query),
+        signal ? { signal } : undefined
+      );
 
       return is.arr(result) ? result : [];
     } catch (err) {
@@ -162,9 +180,10 @@ export class Collection {
    * Returns the document with `_id` populated, or null on failure.
    *
    * @param {object} doc
+   * @param {object} [options] - { signal? }
    * @returns {Promise<object | null>}
    */
-  async save(doc) {
+  async save(doc, options) {
     if (!is.obj(doc)) {
       return null;
     }
@@ -172,11 +191,17 @@ export class Collection {
     try {
       const col = await this.client.open(this.name);
       const prepared = prepare(doc);
+      const signal = signalOf(options);
 
       if (prepared._id != null) {
-        const result = await col.replaceOne({ _id: prepared._id }, prepared, {
-          upsert: true
-        });
+        const replaceOpts = signal
+          ? { upsert: true, signal }
+          : { upsert: true };
+        const result = await col.replaceOne(
+          { _id: prepared._id },
+          prepared,
+          replaceOpts
+        );
 
         const touched =
           result.upsertedCount + result.modifiedCount + result.matchedCount;
@@ -184,7 +209,10 @@ export class Collection {
         return touched > 0 ? prepared : null;
       }
 
-      const result = await col.insertOne(prepared);
+      const result = await col.insertOne(
+        prepared,
+        signal ? { signal } : undefined
+      );
 
       return result.insertedId ? { ...prepared, _id: result.insertedId } : null;
     } catch (err) {
@@ -199,9 +227,10 @@ export class Collection {
    * failure.
    *
    * @param {object[]} docs
+   * @param {object} [options] - { signal? }
    * @returns {Promise<object[]>}
    */
-  async saveAll(docs) {
+  async saveAll(docs, options) {
     if (!is.arr(docs)) {
       return [];
     }
@@ -219,7 +248,10 @@ export class Collection {
 
     try {
       const col = await this.client.open(this.name);
-      const result = await col.insertMany(prepared, { ordered: false });
+      const result = await col.insertMany(
+        prepared,
+        withSignal({ ordered: false }, options)
+      );
 
       return prepared.map((d, idx) => ({
         ...d,
@@ -241,12 +273,12 @@ export class Collection {
    *
    * `options.arrayFilters` is forwarded to the driver to support positional
    * filtered updates (e.g. `{ $set: { 'links.$[el].uri': '/new' } }` with
-   * `arrayFilters: [{ 'el.type': 'related' }]`). No other driver options are
-   * exposed.
+   * `arrayFilters: [{ 'el.type': 'related' }]`). `options.signal` cancels the
+   * operation. No other driver options are exposed.
    *
    * @param {object} query
    * @param {object} update - Mongo update operators (e.g. {$set: {...}})
-   * @param {object} [options] - { arrayFilters? }
+   * @param {object} [options] - { arrayFilters?, signal? }
    * @returns {Promise<boolean>} True if at least one document was modified
    */
   async update(query, update, options) {
@@ -261,11 +293,10 @@ export class Collection {
 
     try {
       const col = await this.client.open(this.name);
-      const driverOptions = buildUpdateOptions(options);
       const result = await col.updateMany(
         prepare(query),
         update,
-        driverOptions
+        buildUpdateOptions(options)
       );
 
       return result.modifiedCount > 0;
@@ -282,9 +313,10 @@ export class Collection {
    * are rejected to prevent accidentally wiping the collection.
    *
    * @param {object} query
+   * @param {object} [options] - { signal? }
    * @returns {Promise<boolean>} True if at least one document was deleted
    */
-  async remove(query) {
+  async remove(query, options) {
     if (!isNonEmptyFilter(query)) {
       this.client.emit(new Error('empty filter rejected'), {
         method: 'remove',
@@ -296,7 +328,10 @@ export class Collection {
 
     try {
       const col = await this.client.open(this.name);
-      const result = await col.deleteMany(prepare(query));
+      const result = await col.deleteMany(
+        prepare(query),
+        withSignal(undefined, options)
+      );
 
       return result.deletedCount > 0;
     } catch (err) {
@@ -309,12 +344,16 @@ export class Collection {
    * Delete a single document by id.
    *
    * @param {unknown} id
+   * @param {object} [options] - { signal? }
    * @returns {Promise<boolean>}
    */
-  async removeById(id) {
+  async removeById(id, options) {
     try {
       const col = await this.client.open(this.name);
-      const result = await col.deleteOne(prepare({ _id: id }));
+      const result = await col.deleteOne(
+        prepare({ _id: id }),
+        withSignal(undefined, options)
+      );
 
       return result.deletedCount > 0;
     } catch (err) {
@@ -393,11 +432,19 @@ export class Collection {
 }
 
 function buildUpdateOptions(options) {
-  if (!is.obj(options) || !is.arr(options.arrayFilters)) {
+  if (!is.obj(options)) {
     return undefined;
   }
 
-  return { arrayFilters: options.arrayFilters };
+  const out = {};
+  if (is.arr(options.arrayFilters)) {
+    out.arrayFilters = options.arrayFilters;
+  }
+  if (options.signal) {
+    out.signal = options.signal;
+  }
+
+  return Object.keys(out).length ? out : undefined;
 }
 
 function buildFindOptions(options) {
@@ -419,8 +466,23 @@ function buildFindOptions(options) {
   if (options.sort) {
     out.sort = options.sort;
   }
+  if (options.signal) {
+    out.signal = options.signal;
+  }
 
   return Object.keys(out).length ? out : undefined;
+}
+
+function signalOf(options) {
+  return is.obj(options) ? options.signal : undefined;
+}
+
+function withSignal(driverOpts, options) {
+  const signal = signalOf(options);
+  if (!signal) {
+    return driverOpts;
+  }
+  return { ...driverOpts, signal };
 }
 
 function normalizeProjection(options) {

--- a/test/abort-signal.js
+++ b/test/abort-signal.js
@@ -1,0 +1,234 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { describe, test, before, after, beforeEach } from 'node:test';
+
+import { MongoClient } from '../lib/index.js';
+
+const COLLECTION = `easymongo_abort_${randomUUID()}`;
+
+function abortedSignal() {
+  const ctrl = new AbortController();
+  ctrl.abort();
+  return ctrl.signal;
+}
+
+async function withClient(fn) {
+  const captured = [];
+  const mongo = new MongoClient(
+    { dbname: 'test' },
+    { onError: (err, ctx) => captured.push({ err, ctx }) }
+  );
+  try {
+    await fn(mongo, captured);
+  } finally {
+    await mongo.close();
+  }
+}
+
+const seedClient = new MongoClient({ dbname: 'test' }, { silent: true });
+
+async function wipe() {
+  const native = await seedClient.open(COLLECTION);
+  await native.deleteMany({});
+}
+
+before(wipe);
+after(async () => {
+  await wipe();
+  await seedClient.close();
+});
+beforeEach(wipe);
+
+describe('AbortSignal — pre-aborted collapses to empty default', () => {
+  test('find returns []', async () => {
+    await withClient(async (mongo, captured) => {
+      const col = mongo.collection(COLLECTION);
+      await col.save({ name: 'A' });
+      const result = await col.find({}, { signal: abortedSignal() });
+      assert.deepEqual(result, []);
+      assert.equal(captured.length, 1);
+      assert.equal(captured[0].ctx.method, 'find');
+    });
+  });
+
+  test('findOne returns null', async () => {
+    await withClient(async (mongo, captured) => {
+      const col = mongo.collection(COLLECTION);
+      await col.save({ name: 'A' });
+      const result = await col.findOne(
+        { name: 'A' },
+        { signal: abortedSignal() }
+      );
+      assert.equal(result, null);
+      assert.equal(captured.length, 1);
+      assert.equal(captured[0].ctx.method, 'findOne');
+    });
+  });
+
+  test('exists returns false', async () => {
+    await withClient(async (mongo, captured) => {
+      const col = mongo.collection(COLLECTION);
+      await col.save({ name: 'A' });
+      const result = await col.exists(
+        { name: 'A' },
+        { signal: abortedSignal() }
+      );
+      assert.equal(result, false);
+      assert.equal(captured.length, 1);
+      assert.equal(captured[0].ctx.method, 'exists');
+    });
+  });
+
+  test('count returns 0', async () => {
+    await withClient(async (mongo, captured) => {
+      const col = mongo.collection(COLLECTION);
+      await col.save({ name: 'A' });
+      const result = await col.count({}, { signal: abortedSignal() });
+      assert.equal(result, 0);
+      assert.equal(captured.length, 1);
+      assert.equal(captured[0].ctx.method, 'count');
+    });
+  });
+
+  test('distinct returns []', async () => {
+    await withClient(async (mongo, captured) => {
+      const col = mongo.collection(COLLECTION);
+      await col.save({ tag: 'a' });
+      const result = await col.distinct('tag', {}, { signal: abortedSignal() });
+      assert.deepEqual(result, []);
+      assert.equal(captured.length, 1);
+      assert.equal(captured[0].ctx.method, 'distinct');
+    });
+  });
+
+  test('save returns null (insert path)', async () => {
+    await withClient(async (mongo, captured) => {
+      const col = mongo.collection(COLLECTION);
+      const result = await col.save({ name: 'A' }, { signal: abortedSignal() });
+      assert.equal(result, null);
+      assert.equal(captured.length, 1);
+      assert.equal(captured[0].ctx.method, 'save');
+    });
+  });
+
+  test('saveAll returns []', async () => {
+    await withClient(async (mongo, captured) => {
+      const col = mongo.collection(COLLECTION);
+      const result = await col.saveAll([{ name: 'A' }, { name: 'B' }], {
+        signal: abortedSignal()
+      });
+      assert.deepEqual(result, []);
+      assert.equal(captured.length, 1);
+      assert.equal(captured[0].ctx.method, 'saveAll');
+    });
+  });
+
+  test('update returns false', async () => {
+    await withClient(async (mongo, captured) => {
+      const col = mongo.collection(COLLECTION);
+      await col.save({ name: 'A' });
+      const result = await col.update(
+        { name: 'A' },
+        { $set: { x: 1 } },
+        { signal: abortedSignal() }
+      );
+      assert.equal(result, false);
+      assert.equal(captured.length, 1);
+      assert.equal(captured[0].ctx.method, 'update');
+    });
+  });
+
+  test('remove returns false', async () => {
+    await withClient(async (mongo, captured) => {
+      const col = mongo.collection(COLLECTION);
+      await col.save({ name: 'A' });
+      const result = await col.remove(
+        { name: 'A' },
+        { signal: abortedSignal() }
+      );
+      assert.equal(result, false);
+      assert.equal(captured.length, 1);
+      assert.equal(captured[0].ctx.method, 'remove');
+    });
+  });
+
+  test('removeById returns false', async () => {
+    await withClient(async (mongo, captured) => {
+      const col = mongo.collection(COLLECTION);
+      const created = await col.save({ name: 'A' });
+      const result = await col.removeById(created._id, {
+        signal: abortedSignal()
+      });
+      assert.equal(result, false);
+      assert.equal(captured.length, 1);
+      assert.equal(captured[0].ctx.method, 'removeById');
+    });
+  });
+});
+
+describe('AbortSignal — aborting mid-flight', () => {
+  test('aborting after a few results still collapses to default', async () => {
+    await withClient(async (mongo, captured) => {
+      const col = mongo.collection(COLLECTION);
+      const docs = Array.from({ length: 200 }, (_, i) => ({ n: i }));
+      await col.saveAll(docs);
+
+      const ctrl = new AbortController();
+      // Schedule abort to fire on next tick — most network calls will see it.
+      queueMicrotask(() => ctrl.abort());
+      const result = await col.find({}, { signal: ctrl.signal });
+
+      // Either the find finished synchronously and returns [...all] OR
+      // it was aborted and returns []. Both are valid fail-silent outcomes;
+      // we only assert that no error escapes.
+      assert.ok(Array.isArray(result));
+      assert.ok(captured.length === 0 || captured[0].ctx.method === 'find');
+    });
+  });
+});
+
+describe('AbortSignal — non-aborted signal is a no-op', () => {
+  test('passing a fresh signal does not affect the result', async () => {
+    await withClient(async (mongo) => {
+      const col = mongo.collection(COLLECTION);
+      const ctrl = new AbortController();
+      await col.save({ name: 'A' });
+      const result = await col.find({}, { signal: ctrl.signal });
+      assert.equal(result.length, 1);
+      assert.equal(result[0].name, 'A');
+    });
+  });
+
+  test('signal alongside other options preserves both behaviours', async () => {
+    await withClient(async (mongo) => {
+      const col = mongo.collection(COLLECTION);
+      const ctrl = new AbortController();
+      await col.saveAll([
+        { name: 'A', n: 3 },
+        { name: 'B', n: 1 },
+        { name: 'C', n: 2 }
+      ]);
+      const result = await col.find(
+        {},
+        { sort: { n: 1 }, limit: 2, signal: ctrl.signal }
+      );
+      assert.equal(result.length, 2);
+      assert.equal(result[0].n, 1);
+      assert.equal(result[1].n, 2);
+    });
+  });
+});
+
+describe('AbortSignal — caller can detect abort via signal.aborted', () => {
+  test('signal.aborted is true after abort even when result is empty default', async () => {
+    await withClient(async (mongo) => {
+      const col = mongo.collection(COLLECTION);
+      await col.save({ name: 'A' });
+      const ctrl = new AbortController();
+      ctrl.abort();
+      const result = await col.find({}, { signal: ctrl.signal });
+      assert.deepEqual(result, []);
+      assert.equal(ctrl.signal.aborted, true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Every async method on `Collection` now accepts an optional `{ signal }` and forwards it to the underlying driver call:

- `find` / `findOne` — `signal` added to find options.
- `exists` / `count` / `distinct` — new options arg with signal.
- `save` — signal forwarded to both `insertOne` and `replaceOne` paths.
- `saveAll` — signal forwarded to `insertMany`.
- `update` — new options arg with signal (plays nicely with existing third-arg surface from #17).
- `remove` / `removeById` — new options arg with signal.

When the signal is already aborted (or fires mid-flight), the driver throws `AbortError`, which the existing try/catch collapses into the method's empty default + `_emit`. **The fail-silent contract is unchanged** — public methods still never throw.

Callers that need to distinguish "aborted" from "empty result" check `signal.aborted` after the await — same pattern Node uses for `fs/promises` and other AbortController-aware APIs.

`findById` is intentionally not extended — its second positional arg is already overloaded (fields shortcut). Callers that need signal-aware id lookup use `findOne({ id }, { signal })` directly; the `id` alias is recognised by `prepare()`.

## Test plan
- [x] `pnpm test` — all 129 tests pass (13 new in `test/abort-signal.js` covering pre-aborted, mid-flight, fresh-signal-as-noop, and abort-detection-via-signal.aborted).
- [x] `pnpm lint` — clean.
- [x] `pnpm format:check` — clean.
- [x] CI matrix.

## Context

Part of the yamb wishlist landing — see `plan/yamb-architecture-decisions.md` on `feature/yamb-request`. Required for the storage contract's cancellation semantics, and a prerequisite for the upcoming `findCursor` PR.