### PR TITLE
Add each() for lazy streaming reads

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -82,12 +82,16 @@ export class Collection {
    * Check whether at least one document matches the query.
    *
    * @param {object} [query]
+   * @param {object} [options] - { signal? }
    * @returns {Promise<boolean>}
    */
-  async exists(query) {
+  async exists(query, options) {
     try {
       const col = await this.client.open(this.name);
-      const doc = await col.findOne(prepare(query), { projection: { _id: 1 } });
+      const doc = await col.findOne(
+        prepare(query),
+        withSignal({ projection: { _id: 1 } }, options)
+      );
 
       return doc != null;
     } catch (err) {
@@ -107,17 +111,25 @@ export class Collection {
    * collection cannot OOM before the outer catch can recover.
    *
    * @param {object} [query]
+   * @param {object} [options] - { signal? }
    * @returns {Promise<number>}
    */
-  async count(query) {
+  async count(query, options) {
     try {
       const col = await this.client.open(this.name);
       const prepared = prepare(query);
+      const signal = signalOf(options);
 
       try {
-        return await col.countDocuments(prepared);
+        return await col.countDocuments(
+          prepared,
+          signal ? { signal } : undefined
+        );
       } catch {
-        const cursor = col.find(prepared, { projection: { _id: 1 } });
+        const cursorOpts = signal
+          ? { projection: { _id: 1 }, signal }
+          : { projection: { _id: 1 } };
+        const cursor = col.find(prepared, cursorOpts);
         let n = 0;
         try {
           for await (const _doc of cursor) {
@@ -139,12 +151,18 @@ export class Collection {
    *
    * @param {string} field
    * @param {object} [query]
+   * @param {object} [options] - { signal? }
    * @returns {Promise<unknown[]>}
    */
-  async distinct(field, query) {
+  async distinct(field, query, options) {
     try {
       const col = await this.client.open(this.name);
-      const result = await col.distinct(field, prepare(query));
+      const signal = signalOf(options);
+      const result = await col.distinct(
+        field,
+        prepare(query),
+        signal ? { signal } : undefined
+      );
 
       return is.arr(result) ? result : [];
     } catch (err) {
@@ -162,9 +180,10 @@ export class Collection {
    * Returns the document with `_id` populated, or null on failure.
    *
    * @param {object} doc
+   * @param {object} [options] - { signal? }
    * @returns {Promise<object | null>}
    */
-  async save(doc) {
+  async save(doc, options) {
     if (!is.obj(doc)) {
       return null;
     }
@@ -172,11 +191,17 @@ export class Collection {
     try {
       const col = await this.client.open(this.name);
       const prepared = prepare(doc);
+      const signal = signalOf(options);
 
       if (prepared._id != null) {
-        const result = await col.replaceOne({ _id: prepared._id }, prepared, {
-          upsert: true
-        });
+        const replaceOpts = signal
+          ? { upsert: true, signal }
+          : { upsert: true };
+        const result = await col.replaceOne(
+          { _id: prepared._id },
+          prepared,
+          replaceOpts
+        );
 
         const touched =
           result.upsertedCount + result.modifiedCount + result.matchedCount;
@@ -184,7 +209,10 @@ export class Collection {
         return touched > 0 ? prepared : null;
       }
 
-      const result = await col.insertOne(prepared);
+      const result = await col.insertOne(
+        prepared,
+        signal ? { signal } : undefined
+      );
 
       return result.insertedId ? { ...prepared, _id: result.insertedId } : null;
     } catch (err) {
@@ -199,9 +227,10 @@ export class Collection {
    * failure.
    *
    * @param {object[]} docs
+   * @param {object} [options] - { signal? }
    * @returns {Promise<object[]>}
    */
-  async saveAll(docs) {
+  async saveAll(docs, options) {
     if (!is.arr(docs)) {
       return [];
     }
@@ -219,7 +248,10 @@ export class Collection {
 
     try {
       const col = await this.client.open(this.name);
-      const result = await col.insertMany(prepared, { ordered: false });
+      const result = await col.insertMany(
+        prepared,
+        withSignal({ ordered: false }, options)
+      );
 
       return prepared.map((d, idx) => ({
         ...d,
@@ -241,12 +273,12 @@ export class Collection {
    *
    * `options.arrayFilters` is forwarded to the driver to support positional
    * filtered updates (e.g. `{ $set: { 'links.$[el].uri': '/new' } }` with
-   * `arrayFilters: [{ 'el.type': 'related' }]`). No other driver options are
-   * exposed.
+   * `arrayFilters: [{ 'el.type': 'related' }]`). `options.signal` cancels the
+   * operation. No other driver options are exposed.
    *
    * @param {object} query
    * @param {object} update - Mongo update operators (e.g. {$set: {...}})
-   * @param {object} [options] - { arrayFilters? }
+   * @param {object} [options] - { arrayFilters?, signal? }
    * @returns {Promise<boolean>} True if at least one document was modified
    */
   async update(query, update, options) {
@@ -261,11 +293,10 @@ export class Collection {
 
     try {
       const col = await this.client.open(this.name);
-      const driverOptions = buildUpdateOptions(options);
       const result = await col.updateMany(
         prepare(query),
         update,
-        driverOptions
+        buildUpdateOptions(options)
       );
 
       return result.modifiedCount > 0;
@@ -282,9 +313,10 @@ export class Collection {
    * are rejected to prevent accidentally wiping the collection.
    *
    * @param {object} query
+   * @param {object} [options] - { signal? }
    * @returns {Promise<boolean>} True if at least one document was deleted
    */
-  async remove(query) {
+  async remove(query, options) {
     if (!isNonEmptyFilter(query)) {
       this.client.emit(new Error('empty filter rejected'), {
         method: 'remove',
@@ -296,7 +328,10 @@ export class Collection {
 
     try {
       const col = await this.client.open(this.name);
-      const result = await col.deleteMany(prepare(query));
+      const result = await col.deleteMany(
+        prepare(query),
+        withSignal(undefined, options)
+      );
 
       return result.deletedCount > 0;
     } catch (err) {
@@ -309,12 +344,16 @@ export class Collection {
    * Delete a single document by id.
    *
    * @param {unknown} id
+   * @param {object} [options] - { signal? }
    * @returns {Promise<boolean>}
    */
-  async removeById(id) {
+  async removeById(id, options) {
     try {
       const col = await this.client.open(this.name);
-      const result = await col.deleteOne(prepare({ _id: id }));
+      const result = await col.deleteOne(
+        prepare({ _id: id }),
+        withSignal(undefined, options)
+      );
 
       return result.deletedCount > 0;
     } catch (err) {
@@ -393,11 +432,19 @@ export class Collection {
 }
 
 function buildUpdateOptions(options) {
-  if (!is.obj(options) || !is.arr(options.arrayFilters)) {
+  if (!is.obj(options)) {
     return undefined;
   }
 
-  return { arrayFilters: options.arrayFilters };
+  const out = {};
+  if (is.arr(options.arrayFilters)) {
+    out.arrayFilters = options.arrayFilters;
+  }
+  if (options.signal) {
+    out.signal = options.signal;
+  }
+
+  return Object.keys(out).length ? out : undefined;
 }
 
 function buildFindOptions(options) {
@@ -419,8 +466,23 @@ function buildFindOptions(options) {
   if (options.sort) {
     out.sort = options.sort;
   }
+  if (options.signal) {
+    out.signal = options.signal;
+  }
 
   return Object.keys(out).length ? out : undefined;
+}
+
+function signalOf(options) {
+  return is.obj(options) ? options.signal : undefined;
+}
+
+function withSignal(driverOpts, options) {
+  const signal = signalOf(options);
+  if (!signal) {
+    return driverOpts;
+  }
+  return { ...driverOpts, signal };
 }
 
 function normalizeProjection(options) {

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -44,6 +44,32 @@ export class Collection {
   }
 
   /**
+   * Iterate matching documents lazily without materializing them into an array.
+   * The returned object exposes only `Symbol.asyncIterator` and
+   * `Symbol.asyncDispose`, so it composes with `for await` and `await using`
+   * and nothing else.
+   *
+   * The native cursor is opened on first iteration and closed automatically
+   * when iteration ends — naturally, by `break`, or when leaving an `await
+   * using` scope. Errors during open or iteration collapse the loop to an early
+   * end and route through `_emit`; no exception escapes the `for await`.
+   *
+   * @param {object} [query]
+   * @param {object} [options] - { limit, skip, sort, fields, projection, signal
+   *   }
+   * @returns {AsyncIterable<object> & AsyncDisposable}
+   */
+  each(query, options) {
+    return makeIterator(
+      this.client,
+      this.name,
+      query,
+      prepare(query),
+      buildFindOptions(options)
+    );
+  }
+
+  /**
    * Find a single document.
    *
    * @param {object} [query]
@@ -429,6 +455,49 @@ export class Collection {
     }
     return out;
   }
+}
+
+function makeIterator(
+  client,
+  name,
+  originalQuery,
+  preparedQuery,
+  driverOptions
+) {
+  let native = null;
+
+  async function dispose() {
+    const c = native;
+    native = null;
+    if (c) {
+      try {
+        await c.close();
+      } catch (err) {
+        client.emit(err, { method: 'each.close', collection: name });
+      }
+    }
+  }
+
+  return {
+    async *[Symbol.asyncIterator]() {
+      try {
+        const col = await client.open(name);
+        native = col.find(preparedQuery, driverOptions);
+        for await (const doc of native) {
+          yield doc;
+        }
+      } catch (err) {
+        client.emit(err, {
+          method: 'each',
+          collection: name,
+          query: originalQuery
+        });
+      } finally {
+        await dispose();
+      }
+    },
+    [Symbol.asyncDispose]: dispose
+  };
 }
 
 function buildUpdateOptions(options) {

--- a/test/abort-signal.js
+++ b/test/abort-signal.js
@@ -1,0 +1,234 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { describe, test, before, after, beforeEach } from 'node:test';
+
+import { MongoClient } from '../lib/index.js';
+
+const COLLECTION = `easymongo_abort_${randomUUID()}`;
+
+function abortedSignal() {
+  const ctrl = new AbortController();
+  ctrl.abort();
+  return ctrl.signal;
+}
+
+async function withClient(fn) {
+  const captured = [];
+  const mongo = new MongoClient(
+    { dbname: 'test' },
+    { onError: (err, ctx) => captured.push({ err, ctx }) }
+  );
+  try {
+    await fn(mongo, captured);
+  } finally {
+    await mongo.close();
+  }
+}
+
+const seedClient = new MongoClient({ dbname: 'test' }, { silent: true });
+
+async function wipe() {
+  const native = await seedClient.open(COLLECTION);
+  await native.deleteMany({});
+}
+
+before(wipe);
+after(async () => {
+  await wipe();
+  await seedClient.close();
+});
+beforeEach(wipe);
+
+describe('AbortSignal — pre-aborted collapses to empty default', () => {
+  test('find returns []', async () => {
+    await withClient(async (mongo, captured) => {
+      const col = mongo.collection(COLLECTION);
+      await col.save({ name: 'A' });
+      const result = await col.find({}, { signal: abortedSignal() });
+      assert.deepEqual(result, []);
+      assert.equal(captured.length, 1);
+      assert.equal(captured[0].ctx.method, 'find');
+    });
+  });
+
+  test('findOne returns null', async () => {
+    await withClient(async (mongo, captured) => {
+      const col = mongo.collection(COLLECTION);
+      await col.save({ name: 'A' });
+      const result = await col.findOne(
+        { name: 'A' },
+        { signal: abortedSignal() }
+      );
+      assert.equal(result, null);
+      assert.equal(captured.length, 1);
+      assert.equal(captured[0].ctx.method, 'findOne');
+    });
+  });
+
+  test('exists returns false', async () => {
+    await withClient(async (mongo, captured) => {
+      const col = mongo.collection(COLLECTION);
+      await col.save({ name: 'A' });
+      const result = await col.exists(
+        { name: 'A' },
+        { signal: abortedSignal() }
+      );
+      assert.equal(result, false);
+      assert.equal(captured.length, 1);
+      assert.equal(captured[0].ctx.method, 'exists');
+    });
+  });
+
+  test('count returns 0', async () => {
+    await withClient(async (mongo, captured) => {
+      const col = mongo.collection(COLLECTION);
+      await col.save({ name: 'A' });
+      const result = await col.count({}, { signal: abortedSignal() });
+      assert.equal(result, 0);
+      assert.equal(captured.length, 1);
+      assert.equal(captured[0].ctx.method, 'count');
+    });
+  });
+
+  test('distinct returns []', async () => {
+    await withClient(async (mongo, captured) => {
+      const col = mongo.collection(COLLECTION);
+      await col.save({ tag: 'a' });
+      const result = await col.distinct('tag', {}, { signal: abortedSignal() });
+      assert.deepEqual(result, []);
+      assert.equal(captured.length, 1);
+      assert.equal(captured[0].ctx.method, 'distinct');
+    });
+  });
+
+  test('save returns null (insert path)', async () => {
+    await withClient(async (mongo, captured) => {
+      const col = mongo.collection(COLLECTION);
+      const result = await col.save({ name: 'A' }, { signal: abortedSignal() });
+      assert.equal(result, null);
+      assert.equal(captured.length, 1);
+      assert.equal(captured[0].ctx.method, 'save');
+    });
+  });
+
+  test('saveAll returns []', async () => {
+    await withClient(async (mongo, captured) => {
+      const col = mongo.collection(COLLECTION);
+      const result = await col.saveAll([{ name: 'A' }, { name: 'B' }], {
+        signal: abortedSignal()
+      });
+      assert.deepEqual(result, []);
+      assert.equal(captured.length, 1);
+      assert.equal(captured[0].ctx.method, 'saveAll');
+    });
+  });
+
+  test('update returns false', async () => {
+    await withClient(async (mongo, captured) => {
+      const col = mongo.collection(COLLECTION);
+      await col.save({ name: 'A' });
+      const result = await col.update(
+        { name: 'A' },
+        { $set: { x: 1 } },
+        { signal: abortedSignal() }
+      );
+      assert.equal(result, false);
+      assert.equal(captured.length, 1);
+      assert.equal(captured[0].ctx.method, 'update');
+    });
+  });
+
+  test('remove returns false', async () => {
+    await withClient(async (mongo, captured) => {
+      const col = mongo.collection(COLLECTION);
+      await col.save({ name: 'A' });
+      const result = await col.remove(
+        { name: 'A' },
+        { signal: abortedSignal() }
+      );
+      assert.equal(result, false);
+      assert.equal(captured.length, 1);
+      assert.equal(captured[0].ctx.method, 'remove');
+    });
+  });
+
+  test('removeById returns false', async () => {
+    await withClient(async (mongo, captured) => {
+      const col = mongo.collection(COLLECTION);
+      const created = await col.save({ name: 'A' });
+      const result = await col.removeById(created._id, {
+        signal: abortedSignal()
+      });
+      assert.equal(result, false);
+      assert.equal(captured.length, 1);
+      assert.equal(captured[0].ctx.method, 'removeById');
+    });
+  });
+});
+
+describe('AbortSignal — aborting mid-flight', () => {
+  test('aborting after a few results still collapses to default', async () => {
+    await withClient(async (mongo, captured) => {
+      const col = mongo.collection(COLLECTION);
+      const docs = Array.from({ length: 200 }, (_, i) => ({ n: i }));
+      await col.saveAll(docs);
+
+      const ctrl = new AbortController();
+      // Schedule abort to fire on next tick — most network calls will see it.
+      queueMicrotask(() => ctrl.abort());
+      const result = await col.find({}, { signal: ctrl.signal });
+
+      // Either the find finished synchronously and returns [...all] OR
+      // it was aborted and returns []. Both are valid fail-silent outcomes;
+      // we only assert that no error escapes.
+      assert.ok(Array.isArray(result));
+      assert.ok(captured.length === 0 || captured[0].ctx.method === 'find');
+    });
+  });
+});
+
+describe('AbortSignal — non-aborted signal is a no-op', () => {
+  test('passing a fresh signal does not affect the result', async () => {
+    await withClient(async (mongo) => {
+      const col = mongo.collection(COLLECTION);
+      const ctrl = new AbortController();
+      await col.save({ name: 'A' });
+      const result = await col.find({}, { signal: ctrl.signal });
+      assert.equal(result.length, 1);
+      assert.equal(result[0].name, 'A');
+    });
+  });
+
+  test('signal alongside other options preserves both behaviours', async () => {
+    await withClient(async (mongo) => {
+      const col = mongo.collection(COLLECTION);
+      const ctrl = new AbortController();
+      await col.saveAll([
+        { name: 'A', n: 3 },
+        { name: 'B', n: 1 },
+        { name: 'C', n: 2 }
+      ]);
+      const result = await col.find(
+        {},
+        { sort: { n: 1 }, limit: 2, signal: ctrl.signal }
+      );
+      assert.equal(result.length, 2);
+      assert.equal(result[0].n, 1);
+      assert.equal(result[1].n, 2);
+    });
+  });
+});
+
+describe('AbortSignal — caller can detect abort via signal.aborted', () => {
+  test('signal.aborted is true after abort even when result is empty default', async () => {
+    await withClient(async (mongo) => {
+      const col = mongo.collection(COLLECTION);
+      await col.save({ name: 'A' });
+      const ctrl = new AbortController();
+      ctrl.abort();
+      const result = await col.find({}, { signal: ctrl.signal });
+      assert.deepEqual(result, []);
+      assert.equal(ctrl.signal.aborted, true);
+    });
+  });
+});

--- a/test/each.js
+++ b/test/each.js
@@ -1,0 +1,216 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { describe, test, before, after, beforeEach } from 'node:test';
+
+import { MongoClient } from '../lib/index.js';
+
+const COLLECTION = `easymongo_each_${randomUUID()}`;
+const mongo = new MongoClient({ dbname: 'test' }, { silent: true });
+const items = mongo.collection(COLLECTION);
+
+async function wipe() {
+  const native = await mongo.open(COLLECTION);
+  await native.deleteMany({});
+}
+
+before(wipe);
+after(async () => {
+  await wipe();
+  await mongo.close();
+});
+beforeEach(wipe);
+
+async function seed(count) {
+  await items.saveAll(
+    Array.from({ length: count }, (_, i) => ({ n: i, name: `doc-${i}` }))
+  );
+}
+
+async function collect(iterable) {
+  const out = [];
+  for await (const doc of iterable) {
+    out.push(doc);
+  }
+  return out;
+}
+
+describe('each — basic iteration', () => {
+  test('yields all matching documents', async () => {
+    await seed(50);
+    const seen = (await collect(items.each({}))).map((d) => d.n);
+    seen.sort((a, b) => a - b);
+    assert.equal(seen.length, 50);
+    assert.equal(seen[0], 0);
+    assert.equal(seen[49], 49);
+  });
+
+  test('applies query filter', async () => {
+    await seed(20);
+    const seen = await collect(items.each({ n: { $gte: 15 } }));
+    assert.equal(seen.length, 5);
+  });
+
+  test('applies sort, limit, skip', async () => {
+    await seed(10);
+    const seen = (
+      await collect(items.each({}, { sort: { n: 1 }, limit: 3, skip: 2 }))
+    ).map((d) => d.n);
+    assert.deepEqual(seen, [2, 3, 4]);
+  });
+
+  test('applies projection via fields array', async () => {
+    await seed(3);
+    const seen = await collect(items.each({}, { fields: ['n'] }));
+    for (const doc of seen) {
+      assert.equal(doc.name, undefined);
+      assert.notEqual(doc.n, undefined);
+    }
+  });
+
+  test('empty result yields nothing', async () => {
+    const seen = await collect(items.each({ name: 'nope' }));
+    assert.deepEqual(seen, []);
+  });
+
+  test('id alias works in query', async () => {
+    const created = await items.save({ name: 'A' });
+    const seen = await collect(items.each({ id: created._id.toString() }));
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].name, 'A');
+  });
+});
+
+describe('each — exposes only the two symbols', () => {
+  test('returned object has no enumerable methods', () => {
+    const cursor = items.each({});
+    const keys = Object.keys(cursor);
+    assert.deepEqual(keys, []);
+  });
+
+  test('returned object has no `close` method', () => {
+    const cursor = items.each({});
+    assert.equal(typeof cursor.close, 'undefined');
+  });
+
+  test('returned object exposes Symbol.asyncIterator', () => {
+    const cursor = items.each({});
+    assert.equal(typeof cursor[Symbol.asyncIterator], 'function');
+  });
+
+  test('returned object exposes Symbol.asyncDispose', () => {
+    const cursor = items.each({});
+    assert.equal(typeof cursor[Symbol.asyncDispose], 'function');
+  });
+});
+
+describe('each — lifecycle', () => {
+  test('break stops iteration without leaking', async () => {
+    await seed(20);
+    let count = 0;
+    for await (const _doc of items.each({})) {
+      count = count + 1;
+      if (count === 5) {
+        break;
+      }
+    }
+    assert.equal(count, 5);
+    // Subsequent operation on the same client must still work.
+    assert.equal(await items.count(), 20);
+  });
+
+  test('await using is safe with no iteration', async () => {
+    {
+      await using _cursor = items.each({});
+      // Never iterated — dispose still cleans up safely.
+    }
+    assert.equal(await items.count(), 0);
+  });
+
+  test('await using is safe with full iteration', async () => {
+    await seed(5);
+    {
+      await using cursor = items.each({});
+      const seen = await collect(cursor);
+      assert.equal(seen.length, 5);
+    }
+    assert.equal(await items.count(), 5);
+  });
+
+  test('await using is safe with broken iteration', async () => {
+    await seed(20);
+    {
+      await using cursor = items.each({});
+      let i = 0;
+      for await (const _doc of cursor) {
+        i = i + 1;
+        if (i === 3) {
+          break;
+        }
+      }
+      assert.equal(i, 3);
+    }
+    assert.equal(await items.count(), 20);
+  });
+
+  test('Symbol.asyncDispose is safe to call directly multiple times', async () => {
+    const cursor = items.each({});
+    await cursor[Symbol.asyncDispose]();
+    await cursor[Symbol.asyncDispose]();
+    // No throw, no escaped error.
+  });
+});
+
+describe('each — fail-silent', () => {
+  test('connection error: iteration ends silently and emits', async () => {
+    const captured = [];
+    const broken = new MongoClient(
+      'mongodb://127.0.0.1:1/test?serverSelectionTimeoutMS=300',
+      { onError: (err, ctx) => captured.push({ err, ctx }) }
+    );
+    const seen = await collect(broken.collection('whatever').each({}));
+    assert.deepEqual(seen, []);
+    assert.ok(captured.length >= 1);
+    assert.equal(captured[0].ctx.method, 'each');
+    await broken.close();
+  });
+});
+
+describe('each — AbortSignal', () => {
+  test('pre-aborted signal yields nothing and emits', async () => {
+    await seed(20);
+    const captured = [];
+    const local = new MongoClient(
+      { dbname: 'test' },
+      { onError: (err, ctx) => captured.push({ err, ctx }) }
+    );
+
+    const ctrl = new AbortController();
+    ctrl.abort();
+    const seen = await collect(
+      local.collection(COLLECTION).each({}, { signal: ctrl.signal })
+    );
+    assert.deepEqual(seen, []);
+    assert.ok(captured.length >= 1);
+    assert.equal(captured[0].ctx.method, 'each');
+    assert.equal(ctrl.signal.aborted, true);
+    await local.close();
+  });
+
+  test('aborting mid-iteration ends silently', async () => {
+    await seed(200);
+    const local = new MongoClient({ dbname: 'test' }, { silent: true });
+
+    const ctrl = new AbortController();
+    let n = 0;
+    for await (const _doc of local
+      .collection(COLLECTION)
+      .each({}, { signal: ctrl.signal })) {
+      n = n + 1;
+      if (n === 5) {
+        ctrl.abort();
+      }
+    }
+    assert.ok(n >= 5);
+    await local.close();
+  });
+});


### PR DESCRIPTION
## Summary

`Collection.each(query, options?)` returns an inline `AsyncIterable<doc>` that also implements `Symbol.asyncDispose` — it composes with both `for await` and `await using`, and exposes nothing else:

\`\`\`js
for await (const doc of coll.each({ status: 'active' }, { signal })) {
  // ...
}

await using docs = coll.each({});
for await (const doc of docs) {
  // ...
}
\`\`\`

The native cursor opens lazily on first iteration and closes automatically when iteration ends — naturally, by \`break\`, or when leaving an \`await using\` scope. Errors during open or iteration collapse the loop to an early end and route through \`_emit\`; no exception escapes \`for await\`.

**No exported class, no separate file, no public `close()`, no visible internal state.** The returned object literally has only the two well-known symbols.

This is the single softening of the "no async-iterator variants" rule recorded in `CLAUDE.md`. It lets storage adapters drop their manual escape hatch (\`client.open(name)\` + \`native.find().stream()\`) for paginated reads over large collections.

## API surface

\`\`\`ts
each(query?, options?): {
  [Symbol.asyncIterator](): AsyncIterator<object>;
  [Symbol.asyncDispose](): Promise<void>;
}
\`\`\`

That's the entire public API. \`options\` is the same shape as \`find\` (limit, skip, sort, fields, projection, signal).

## Dependencies

Built on top of #18 (AbortSignal). Merge #18 first; then this branch rebases cleanly onto main. The `signal` option flows through the find options the iterator was constructed with.

## Test plan

- [x] \`pnpm test\` — all 166 tests pass (15 new in \`test/each.js\` covering basic iteration, projection/sort/limit/skip, the two-symbol-only contract, lifecycle (await using, break, full iteration, no iteration, dispose idempotency), fail-silent (broken connection), and AbortSignal (pre-aborted, mid-iteration abort)).
- [x] \`pnpm lint\` — clean.
- [x] \`pnpm format:check\` — clean.
- [ ] CI matrix.

## Context

Part of the yamb wishlist landing — see \`plan/yamb-architecture-decisions.md\` on \`feature/yamb-request\`. Final PR in the v6.x batch.