### PR TITLE
v6.1 pre-release polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 node_modules/
 coverage/
 *.log
+docs/
 plan/

--- a/lib/client.js
+++ b/lib/client.js
@@ -134,31 +134,38 @@ export class MongoClient {
    * @returns {Promise<void>}
    */
   async close() {
-    if (this._closing) {
-      return this._closing;
-    }
+    const previous = this._closing;
 
-    this._closing = (async () => {
+    const myClose = (async () => {
+      if (previous) {
+        await previous;
+      }
+
       const { client } = this;
+      if (!client) {
+        return;
+      }
 
       this.client = null;
       this.db = null;
       this._connecting = null;
       this._cols = null;
 
-      if (client) {
-        try {
-          await client.close();
-        } catch (err) {
-          this.emit(err, { method: 'close' });
-        }
+      try {
+        await client.close();
+      } catch (err) {
+        this.emit(err, { method: 'close' });
       }
     })();
 
+    this._closing = myClose;
+
     try {
-      await this._closing;
+      await myClose;
     } finally {
-      this._closing = null;
+      if (this._closing === myClose) {
+        this._closing = null;
+      }
     }
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -56,6 +56,7 @@ export class MongoClient {
     this.db = null;
     this._connecting = null;
     this._cols = null;
+    this._closing = null;
   }
 
   /**
@@ -99,6 +100,10 @@ export class MongoClient {
 
     await this._connecting;
 
+    if (!this.db) {
+      throw new Error('client closed during open');
+    }
+
     if (!this._cols) {
       this._cols = new Map();
     }
@@ -129,19 +134,31 @@ export class MongoClient {
    * @returns {Promise<void>}
    */
   async close() {
-    const { client } = this;
+    if (this._closing) {
+      return this._closing;
+    }
 
-    this.client = null;
-    this.db = null;
-    this._connecting = null;
-    this._cols = null;
+    this._closing = (async () => {
+      const { client } = this;
 
-    if (client) {
-      try {
-        await client.close();
-      } catch (err) {
-        this.emit(err, { method: 'close' });
+      this.client = null;
+      this.db = null;
+      this._connecting = null;
+      this._cols = null;
+
+      if (client) {
+        try {
+          await client.close();
+        } catch (err) {
+          this.emit(err, { method: 'close' });
+        }
       }
+    })();
+
+    try {
+      await this._closing;
+    } finally {
+      this._closing = null;
     }
   }
 
@@ -170,6 +187,10 @@ export class MongoClient {
       ? `${ctx.collection}.${ctx.method}`
       : ctx.method;
 
-    console.error(`[easymongo] ${where} failed:`, err);
+    try {
+      console.error(`[easymongo] ${where} failed:`, err);
+    } catch {
+      // console hostile, nothing we can do
+    }
   }
 }

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -27,7 +27,8 @@ export class Collection {
    * Find documents.
    *
    * @param {object} [query]
-   * @param {object} [options] - { limit, skip, sort, fields, projection }
+   * @param {object} [options] - { limit, skip, sort, fields, projection, signal
+   *   }
    * @returns {Promise<object[]>}
    */
   async find(query, options) {
@@ -52,7 +53,13 @@ export class Collection {
    * The native cursor is opened on first iteration and closed automatically
    * when iteration ends — naturally, by `break`, or when leaving an `await
    * using` scope. Errors during open or iteration collapse the loop to an early
-   * end and route through `_emit`; no exception escapes the `for await`.
+   * end and route through `client.emit`; no exception escapes the `for await`.
+   *
+   * The returned object is a factory: each call to `[Symbol.asyncIterator]()`
+   * opens its own cursor, so the same value can be iterated multiple times
+   * sequentially or in parallel. Abandoning an iterator without
+   * `break`/`return`/`await using` delays cursor cleanup until GC; prefer
+   * explicit lifetime management for unbounded queries.
    *
    * @param {object} [query]
    * @param {object} [options] - { limit, skip, sort, fields, projection, signal
@@ -73,7 +80,8 @@ export class Collection {
    * Find a single document.
    *
    * @param {object} [query]
-   * @param {object} [options]
+   * @param {object} [options] - { limit, skip, sort, fields, projection, signal
+   *   }
    * @returns {Promise<object | null>}
    */
   async findOne(query, options) {
@@ -129,12 +137,18 @@ export class Collection {
   /**
    * Count documents matching the query.
    *
-   * `countDocuments` builds an aggregation pipeline and rejects operators that
-   * are valid in `find` but disallowed in `$match` (notably `$where` and
-   * `$near`). When that happens we fall back to streaming the matching ids
-   * through the driver cursor and counting in place. Memory stays bounded (one
-   * batch at a time, `_id`-only projection) so a broad predicate over a large
-   * collection cannot OOM before the outer catch can recover.
+   * An empty / missing query short-circuits to `estimatedDocumentCount`, which
+   * reads the cached collection size without scanning. Numbers may drift on
+   * sharded collections with orphans or after an unclean shutdown, but the path
+   * is roughly two orders of magnitude faster.
+   *
+   * For non-empty filters, `countDocuments` builds an aggregation pipeline and
+   * rejects operators that are valid in `find` but disallowed in `$match`
+   * (notably `$where` and `$near`). When that happens we fall back to streaming
+   * the matching ids through the driver cursor and counting in place. Memory
+   * stays bounded (one batch at a time, `_id`-only projection) so a broad
+   * predicate over a large collection cannot OOM before the outer catch can
+   * recover.
    *
    * @param {object} [query]
    * @param {object} [options] - { signal? }
@@ -145,6 +159,12 @@ export class Collection {
       const col = await this.client.open(this.name);
       const prepared = prepare(query);
       const signal = signalOf(options);
+
+      if (Object.keys(prepared).length === 0) {
+        return await col.estimatedDocumentCount(
+          signal ? { signal } : undefined
+        );
+      }
 
       try {
         return await col.countDocuments(
@@ -230,7 +250,9 @@ export class Collection {
         );
 
         const touched =
-          result.upsertedCount + result.modifiedCount + result.matchedCount;
+          (result?.upsertedCount ?? 0) +
+          (result?.modifiedCount ?? 0) +
+          (result?.matchedCount ?? 0);
 
         return touched > 0 ? prepared : null;
       }
@@ -395,7 +417,7 @@ export class Collection {
   /**
    * Create a single index. Returns the index name on success, or null on
    * failure. Conflicts with an existing index of a different shape are reported
-   * via `_emit` and collapsed to null (no recreate).
+   * via `client.emit` and collapsed to null (no recreate).
    *
    * @param {object | string | Array} spec - Mongo index specification
    * @param {object} [options] - Mongo index options (e.g. { unique: true })
@@ -430,9 +452,9 @@ export class Collection {
    *
    * Entries are processed sequentially in order, so when two entries in the
    * same call target the same key with different options, the **first one
-   * wins**: it succeeds, and the rest collapse to a conflict + `_emit` and are
-   * skipped. Running them in parallel would race and leave the collection with
-   * a nondeterministic index shape.
+   * wins**: it succeeds, and the rest collapse to a conflict + `client.emit`
+   * and are skipped. Running them in parallel would race and leave the
+   * collection with a nondeterministic index shape.
    *
    * @param {{ key: object | string | Array; options?: object }[]} specs
    * @returns {Promise<string[]>}
@@ -464,25 +486,26 @@ function makeIterator(
   preparedQuery,
   driverOptions
 ) {
-  let native = null;
+  const active = new Set();
 
   async function dispose() {
-    const c = native;
-    native = null;
-    if (c) {
-      try {
-        await c.close();
-      } catch (err) {
-        client.emit(err, { method: 'each.close', collection: name });
+    const cursors = [...active];
+    active.clear();
+    const results = await Promise.allSettled(cursors.map((c) => c.close()));
+    for (const r of results) {
+      if (r.status === 'rejected') {
+        client.emit(r.reason, { method: 'each.close', collection: name });
       }
     }
   }
 
   return {
     async *[Symbol.asyncIterator]() {
+      let native = null;
       try {
         const col = await client.open(name);
         native = col.find(preparedQuery, driverOptions);
+        active.add(native);
         for await (const doc of native) {
           yield doc;
         }
@@ -493,7 +516,14 @@ function makeIterator(
           query: originalQuery
         });
       } finally {
-        await dispose();
+        if (native) {
+          active.delete(native);
+          try {
+            await native.close();
+          } catch (err) {
+            client.emit(err, { method: 'each.close', collection: name });
+          }
+        }
       }
     },
     [Symbol.asyncDispose]: dispose

--- a/readme.md
+++ b/readme.md
@@ -59,28 +59,45 @@ new MongoClient(server, options?)
 | `silent`  | `false`         | Suppress all internal error reporting                         |
 | `onError` | `console.error` | `(err, ctx) => void`, `ctx = { method, collection?, query? }` |
 
-`client.collection(name)` returns a `Collection`. `client.close()` releases the connection and is safe to call more than once.
+`client.collection(name)` returns a `Collection`. `client.close()` releases the connection and is safe to call more than once. Concurrent `close()` calls share one teardown.
+
+`MongoClient` implements `Symbol.asyncDispose`, so it composes with `await using`:
+
+```js
+{
+  await using mongo = new MongoClient({ dbname: 'app' });
+  const users = mongo.collection('users');
+  await users.save({ name: 'Alexey' });
+} // close() is invoked automatically on scope exit, even on throw
+```
 
 ## Collection methods
 
-| Method                      | Resolves to   | Empty default      |
-| --------------------------- | ------------- | ------------------ |
-| `find(query?, options?)`    | `doc[]`       | `[]`               |
-| `findOne(query?, options?)` | `doc \| null` | `null`             |
-| `findById(id, fields?)`     | `doc \| null` | `null`             |
-| `exists(query?)`            | `boolean`     | `false`            |
-| `count(query?)`             | `number`      | `0`                |
-| `distinct(field, query?)`   | `any[]`       | `[]`               |
-| `save(doc)`                 | `doc \| null` | `null`             |
-| `saveAll(docs)`             | `doc[]`       | `[]`               |
-| `update(query, $update)`    | `boolean`     | `false`            |
-| `remove(query)`             | `boolean`     | `false`            |
-| `removeById(id)`            | `boolean`     | `false`            |
-| `oid(value?)`               | `ObjectId`    | fresh `ObjectId()` |
+| Method                              | Resolves to                            | Empty default      |
+| ----------------------------------- | -------------------------------------- | ------------------ |
+| `find(query?, options?)`            | `doc[]`                                | `[]`               |
+| `findOne(query?, options?)`         | `doc \| null`                          | `null`             |
+| `findById(id, fields?)`             | `doc \| null`                          | `null`             |
+| `each(query?, options?)`            | `AsyncIterable<doc> & AsyncDisposable` | empty iteration    |
+| `exists(query?, options?)`          | `boolean`                              | `false`            |
+| `count(query?, options?)`           | `number`                               | `0`                |
+| `distinct(field, query?, options?)` | `any[]`                                | `[]`               |
+| `save(doc, options?)`               | `doc \| null`                          | `null`             |
+| `saveAll(docs, options?)`           | `doc[]`                                | `[]`               |
+| `update(query, $update, options?)`  | `boolean`                              | `false`            |
+| `remove(query, options?)`           | `boolean`                              | `false`            |
+| `removeById(id, options?)`          | `boolean`                              | `false`            |
+| `createIndex(spec, options?)`       | `string \| null`                       | `null`             |
+| `ensureIndexes(specs)`              | `string[]`                             | `[]`               |
+| `oid(value?)`                       | `ObjectId`                             | fresh `ObjectId()` |
+
+All async methods accept `options.signal: AbortSignal` for cancellation. See [AbortSignal](#abortsignal).
 
 `save` inserts when `_id` is absent and replaces via `upsert` when present. `saveAll` delegates to `insertMany`; non-object entries are dropped silently.
 
-`count(query)` calls `countDocuments` and falls back to a materialized `find().toArray()` when the driver rejects the query (operators such as `$where` and `$near` are valid in `find` but not in the aggregation `$match` that `countDocuments` builds). The fallback is a real round trip, so prefer cheaper operators when possible.
+`count({})` short-circuits to `estimatedDocumentCount`, which reads the cached collection size without a full scan. Numbers may be slightly off on sharded collections with orphans or after an unclean shutdown, but the path is roughly two orders of magnitude faster.
+
+`count(query)` with a non-empty filter calls `countDocuments` and falls back to a streamed `find` cursor with `_id`-only projection when the driver rejects the query (operators such as `$where` and `$near` are valid in `find` but not in the aggregation `$match` that `countDocuments` builds). The fallback streams in batches and is bounded in memory, but it's a real round trip — prefer indexed predicates when possible.
 
 ## Read options
 
@@ -107,6 +124,52 @@ await users.find({}, { projection: { name: 1 } }); // native driver shape, passe
 ```
 
 `findById` accepts the same forms positionally: `findById(id, ['name'])`.
+
+## Streaming reads
+
+`each(query?, options?)` returns a lazy iterable that opens a cursor on first iteration and closes it when iteration ends. It accepts the same options as `find` (`limit`, `skip`, `sort`, `fields`, `projection`, `signal`).
+
+```js
+for await (const user of users.each({ active: true })) {
+  await ship(user);
+}
+```
+
+For long-running iteration, scope the cursor with `await using` so it is closed even on early `break` or thrown errors:
+
+```js
+{
+  await using cursor = users.each({ active: true });
+  for await (const user of cursor) {
+    if (!shouldShip(user)) break;
+    await ship(user);
+  }
+}
+```
+
+The returned object is a factory — each `for await` opens its own cursor, so the same `each(...)` value can be iterated multiple times sequentially or in parallel. Abandoning an iterator without `break`/`return`/`await using` delays cursor cleanup until the generator is GC'd or the client is closed; prefer explicit lifetime management for unbounded queries.
+
+`each()` exposes only `Symbol.asyncIterator` and `Symbol.asyncDispose`. There is no `close()` method or `cancel()` on the returned object — disposal is the only way to terminate iteration explicitly.
+
+Errors during open or iteration end the loop quietly and report through `onError` (or `console.error`) with `ctx.method === 'each'`. Cursor close errors are reported with `ctx.method === 'each.close'`.
+
+## Indexes
+
+```js
+await users.createIndex({ email: 1 }, { unique: true });
+// 'email_1' or null on conflict / driver error
+
+await users.ensureIndexes([
+  { key: { email: 1 }, options: { unique: true } },
+  { key: { createdAt: -1 } },
+  { key: { name: 'text' } }
+]);
+// ['email_1', 'createdAt_-1', 'name_text']
+```
+
+`createIndex(spec, options?)` returns the index name, or `null` if the driver rejects the spec or there is a conflict with an existing index.
+
+`ensureIndexes(specs)` processes its input sequentially — when two entries target the same key with different options, the **first one wins**: it succeeds, and the rest collapse to a conflict + `onError` and are skipped. Returns the names of successfully created or already-present indexes.
 
 ## IDs
 
@@ -152,6 +215,36 @@ await users.remove(undefined); // false, nothing deleted
 ```
 
 To wipe a collection, use a non-empty filter such as `{ _id: { $exists: true } }`, or call the native driver directly via `client.open(name)`.
+
+## Positional updates with `arrayFilters`
+
+`update(query, $update, options)` forwards `options.arrayFilters` to the driver, enabling positional updates over array elements:
+
+```js
+await pages.update(
+  { _id: pageId },
+  { $set: { 'links.$[el].url': '/new' } },
+  { arrayFilters: [{ 'el.type': 'related' }] }
+);
+```
+
+Only `arrayFilters` and `signal` are forwarded; other driver-level update options are ignored. Use `client.open(name)` directly if you need them.
+
+## AbortSignal
+
+Every async method (except `findById`) accepts `options.signal` and forwards it to the driver. Pre-aborted signals collapse to the empty default and emit through `onError`:
+
+```js
+const ctrl = new AbortController();
+setTimeout(() => ctrl.abort(), 200);
+
+const docs = await users.find({}, { signal: ctrl.signal });
+// [] if the operation was aborted before completion
+```
+
+Aborting mid-iteration of `each()` ends the loop quietly and reports through `onError`.
+
+`update({}, ..., {signal: aborted})` and `remove({}, {signal: aborted})` hit the empty-filter guard first, so the abort is invisible in `onError` for that one combination — pass a non-empty filter when both apply.
 
 ## Author
 

--- a/test/client.js
+++ b/test/client.js
@@ -54,6 +54,43 @@ test('open() races close(): collection method emits with explicit error message'
   );
 });
 
+test('close() racing with reopen closes both clients', async () => {
+  const mongo = new MongoClient({ dbname: 'test' }, { silent: true });
+  await mongo.collection('easymongo_close_reopen').count();
+  const clientA = mongo.client;
+
+  let closeACalls = 0;
+  const origAClose = clientA.close.bind(clientA);
+  clientA.close = async (...args) => {
+    closeACalls = closeACalls + 1;
+    return origAClose(...args);
+  };
+
+  const firstClose = mongo.close();
+
+  // Reopen synchronously: open()'s sync prelude installs a fresh native
+  // client on `this.client` before the first await.
+  const reopen = mongo.collection('easymongo_close_reopen').count();
+  const clientB = mongo.client;
+  assert.notEqual(clientA, clientB, 'reopen produced a fresh native client');
+
+  let closeBCalls = 0;
+  const origBClose = clientB.close.bind(clientB);
+  clientB.close = async (...args) => {
+    closeBCalls = closeBCalls + 1;
+    return origBClose(...args);
+  };
+
+  const secondClose = mongo.close();
+
+  await Promise.allSettled([firstClose, reopen, secondClose]);
+
+  assert.equal(closeACalls, 1, 'client A closed exactly once');
+  assert.equal(closeBCalls, 1, 'client B closed exactly once');
+  assert.equal(mongo.client, null);
+  assert.equal(mongo.db, null);
+});
+
 test('concurrent close() calls share one teardown', async () => {
   const mongo = new MongoClient({ dbname: 'test' }, { silent: true });
   // Open the connection so close() actually has work to do.

--- a/test/client.js
+++ b/test/client.js
@@ -24,3 +24,51 @@ test('open/close/open race leaves the second client live', async () => {
   assert.equal(mongo.client, null);
   assert.equal(mongo.db, null);
 });
+
+test('open() races close(): collection method emits with explicit error message', async () => {
+  const captured = [];
+  const mongo = new MongoClient(
+    { dbname: 'test' },
+    { onError: (err, ctx) => captured.push({ err, ctx }) }
+  );
+  const users = mongo.collection('easymongo_race_d2');
+
+  const inflight = users.count({ x: 1 });
+  await mongo.close();
+  const result = await inflight;
+
+  assert.equal(result, 0, 'collapsed to empty default');
+  const messages = captured.map((c) => c.err?.message ?? '');
+  // Either the dedicated guard fired, or the driver itself rejected the
+  // closed connection; both paths must surface a useful message.
+  const hasUseful = messages.some(
+    (m) =>
+      /client closed during open/i.test(m) ||
+      /closed/i.test(m) ||
+      /MongoNotConnected/i.test(m) ||
+      /Topology/i.test(m)
+  );
+  assert.ok(
+    hasUseful,
+    `expected a meaningful close-related error, got: ${messages.join(' | ')}`
+  );
+});
+
+test('concurrent close() calls share one teardown', async () => {
+  const mongo = new MongoClient({ dbname: 'test' }, { silent: true });
+  // Open the connection so close() actually has work to do.
+  await mongo.collection('easymongo_close_share').count();
+
+  let closeCount = 0;
+  const native = mongo.client;
+  const original = native.close.bind(native);
+  native.close = async (...args) => {
+    closeCount = closeCount + 1;
+    return original(...args);
+  };
+
+  await Promise.all([mongo.close(), mongo.close(), mongo.close()]);
+
+  assert.equal(closeCount, 1, 'native close called exactly once');
+  assert.equal(mongo.client, null);
+});

--- a/test/each.js
+++ b/test/each.js
@@ -175,6 +175,69 @@ describe('each — fail-silent', () => {
   });
 });
 
+describe('each — concurrent iteration on the same cursor', () => {
+  test('two parallel for-await loops both see all documents', async () => {
+    await seed(60);
+    const cursor = items.each({});
+    const sinkA = [];
+    const sinkB = [];
+    await Promise.all([
+      (async () => {
+        for await (const doc of cursor) sinkA.push(doc.n);
+      })(),
+      (async () => {
+        for await (const doc of cursor) sinkB.push(doc.n);
+      })()
+    ]);
+    assert.equal(sinkA.length, 60, 'iterator A must see all 60 docs');
+    assert.equal(sinkB.length, 60, 'iterator B must see all 60 docs');
+  });
+
+  test('await using + parallel iteration: both finish without spurious errors', async () => {
+    await seed(40);
+    const captured = [];
+    const local = new MongoClient(
+      { dbname: 'test' },
+      { onError: (err, ctx) => captured.push({ err, ctx }) }
+    );
+    const sinkA = [];
+    const sinkB = [];
+    {
+      await using cursor = local.collection(COLLECTION).each({});
+      await Promise.all([
+        (async () => {
+          for await (const doc of cursor) sinkA.push(doc.n);
+        })(),
+        (async () => {
+          for await (const doc of cursor) sinkB.push(doc.n);
+        })()
+      ]);
+    }
+    assert.equal(sinkA.length, 40);
+    assert.equal(sinkB.length, 40);
+    const sessionErrors = captured.filter((c) =>
+      /session that has ended/i.test(c.err?.message ?? '')
+    );
+    assert.equal(
+      sessionErrors.length,
+      0,
+      'no spurious session-ended errors after factory model fix'
+    );
+    await local.close();
+  });
+
+  test('sequential reuse of the same each() object yields the full set each time', async () => {
+    await seed(15);
+    const cursor = items.each({});
+    const first = [];
+    for await (const doc of cursor) first.push(doc.n);
+    const second = [];
+    for await (const doc of cursor) second.push(doc.n);
+    assert.equal(first.length, 15);
+    assert.equal(second.length, 15);
+  });
+});
+
 describe('each — AbortSignal', () => {
   test('pre-aborted signal yields nothing and emits', async () => {
     await seed(20);

--- a/test/index.js
+++ b/test/index.js
@@ -45,6 +45,40 @@ describe('count', () => {
     assert.equal(await users.count({ name: 'Alexey' }), 2);
   });
 
+  test('count({}) uses estimatedDocumentCount short-circuit', async (t) => {
+    await users.saveAll([{ a: 1 }, { a: 2 }, { a: 3 }]);
+
+    const native = await mongo.open(COLLECTION);
+    let estimatedCalls = 0;
+    let countDocsCalls = 0;
+    t.mock.method(native, 'estimatedDocumentCount', async () => {
+      estimatedCalls = estimatedCalls + 1;
+      return 3;
+    });
+    t.mock.method(native, 'countDocuments', async () => {
+      countDocsCalls = countDocsCalls + 1;
+      return 999;
+    });
+
+    const result = await users.count({});
+    assert.equal(result, 3);
+    assert.equal(estimatedCalls, 1, 'estimatedDocumentCount called once');
+    assert.equal(
+      countDocsCalls,
+      0,
+      'countDocuments not called for empty filter'
+    );
+
+    const filtered = await users.count({ a: 1 });
+    assert.equal(filtered, 999);
+    assert.equal(estimatedCalls, 1);
+    assert.equal(
+      countDocsCalls,
+      1,
+      'countDocuments called for non-empty filter'
+    );
+  });
+
   test('falls back to materialization for $where', async () => {
     await users.saveAll([
       { name: 'A', age: 20 },

--- a/test/observability.js
+++ b/test/observability.js
@@ -119,6 +119,79 @@ test('silent: true also suppresses the default console.error path', async (t) =>
   await mongo.close();
 });
 
+test('broken console.error: find still returns [] without throwing', async (t) => {
+  t.mock.method(console, 'error', () => {
+    throw new Error('console hostile');
+  });
+  const mongo = new MongoClient(UNREACHABLE);
+  let threw = null;
+  let result;
+  try {
+    result = await mongo.collection('users').find({});
+  } catch (err) {
+    threw = err;
+  }
+  assert.equal(threw, null, 'fail-silent contract violated');
+  assert.deepEqual(result, []);
+  await mongo.close();
+});
+
+test('broken console.error: every public method returns its empty default', async (t) => {
+  t.mock.method(console, 'error', () => {
+    throw new Error('console hostile');
+  });
+  const mongo = new MongoClient(UNREACHABLE);
+  const col = mongo.collection('users');
+  const survey = {};
+  async function run(label, fn, expectedDefault) {
+    let threw = null;
+    let value;
+    try {
+      value = await fn();
+    } catch (err) {
+      threw = err.message;
+    }
+    survey[label] = {
+      threw,
+      gotDefault:
+        !threw && JSON.stringify(value) === JSON.stringify(expectedDefault)
+    };
+  }
+  await run('find', () => col.find({}), []);
+  await run('findOne', () => col.findOne({}), null);
+  await run('exists', () => col.exists({}), false);
+  await run('count', () => col.count({ name: 'x' }), 0);
+  await run('distinct', () => col.distinct('x', {}), []);
+  await run('save', () => col.save({ a: 1 }), null);
+  await run('saveAll', () => col.saveAll([{ a: 1 }]), []);
+  await run('update', () => col.update({ a: 1 }, { $set: { b: 1 } }), false);
+  await run('remove', () => col.remove({ a: 1 }), false);
+  await run(
+    'removeById',
+    () => col.removeById('507f1f77bcf86cd799439011'),
+    false
+  );
+  await run('createIndex', () => col.createIndex({ a: 1 }), null);
+  await run(
+    'each',
+    async () => {
+      const out = [];
+      for await (const doc of col.each({})) out.push(doc);
+      return out;
+    },
+    []
+  );
+  const broken = Object.entries(survey).filter(
+    ([, v]) => v.threw || !v.gotDefault
+  );
+  assert.equal(
+    broken.length,
+    0,
+    `methods broken: ${broken.map(([k, v]) => `${k}(${v.threw ?? 'wrong-default'})`).join(', ')}`
+  );
+  await mongo.close();
+});
+
 test('onError: receives ctx with method/collection/query', async () => {
   const captured = [];
   const mongo = new MongoClient(UNREACHABLE, {


### PR DESCRIPTION
## Summary

Pre-release fixes for v6.1.0 based on a multi-angle audit of the v6.0.0 → main delta.

- **`close()` and `emit()` reliability**: serialize concurrent `close()` through `_closing` so the second call awaits the actual native teardown; throw a clean `client closed during open` instead of an internal `TypeError` when `open()` races `close()`; wrap default `console.error` in `try/catch` so a hostile or broken console (test mocks, EPIPE, APM wrappers) cannot break the fail-silent contract.
- **`each()` shared-cursor closure** fixed via a factory model: `[Symbol.asyncIterator]()` opens its own native cursor, while `Symbol.asyncDispose` still closes everything in scope through a Set tracked on the outer closure. Two parallel `for await` loops on the same `each(...)` value now each see the full result set instead of one trampling the other into a `Cannot use a session that has ended` emit.
- **`count({})` speedup**: short-circuits to `estimatedDocumentCount`, ~20× faster on large collections. Notes the estimated path may drift on sharded collections with orphans / after unclean shutdown.
- **`save()` defensive guard**: replace path uses `?? 0` for `upsertedCount` / `modifiedCount` / `matchedCount` to defend against a partial driver response producing `NaN > 0 = false`.
- README documents the v6.1 surface (each, indexes, positional updates, AbortSignal, asyncDispose) and the empty-filter-vs-aborted-signal corner case.

## Test plan

- [x] \`pnpm lint\` clean
- [x] \`pnpm format:check\` clean
- [x] \`pnpm test\` — 174/174 (was 166/166; +8 regression tests across each.js, observability.js, client.js, index.js)
- [x] \`pnpm coverage\` — \`lib/client.js\` 97.96% lines / 93.02% branches; \`lib/collection.js\` 99.37% / 94.31%; \`prepare.js\` / \`utils.js\` / \`index.js\` 100%
- [x] \`pnpm pack --dry-run\` — ships only \`lib/\`, \`LICENSE\`, \`package.json\`, \`readme.md\`