### PR TITLE
6.2: Per-operation timeout and onError, hostile-input hardening, cursor reclamation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   test:
@@ -21,8 +21,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["24.x", "25.x"]
-        mongo-version: ["7.0", "8.0", "8.2"]
+        node-version: ["24.x", "26.x"]
+        mongo-version: ["7.0", "8.0", "8.2", "8.3"]
+        include:
+          - node-version: "24.x"
+            mongo-version: "8.3"
+            coverage: true
 
     services:
       mongo:
@@ -38,10 +42,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - uses: actions/setup-node@v6
         with:
@@ -49,17 +53,20 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
-      - run: pnpm exec oxlint --format=github
+      - run: pnpm lint --format=github
       - run: pnpm format:check
-      - run: pnpm test
+
+      - if: ${{ !matrix.coverage }}
+        run: pnpm test
 
       - name: Coverage
-        if: matrix.node-version == '24.x' && matrix.mongo-version == '8.2'
+        if: matrix.coverage
         run: pnpm coverage
 
       - name: Upload coverage to Coveralls
-        if: matrix.node-version == '24.x' && matrix.mongo-version == '8.2'
+        if: matrix.coverage
         uses: coverallsapp/github-action@v2
         with:
           file: coverage/lcov.info
           format: lcov
+          fail-on-error: false

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["eslint", "unicorn", "oxc", "import", "promise", "node"],
+  "plugins": ["eslint", "unicorn", "oxc", "import", "promise", "node", "jsdoc"],
   "env": {
     "node": true,
     "es2026": true
@@ -12,7 +12,12 @@
     "perf": "error"
   },
   "rules": {
+    "complexity": "error",
     "eqeqeq": ["error", "always", { "null": "ignore" }],
+    "max-depth": "error",
+    "max-nested-callbacks": "error",
+    "no-else-return": "error",
+    "no-lonely-if": "error",
     "no-constructor-return": "error",
     "no-duplicate-imports": "error",
     "no-promise-executor-return": "error",
@@ -43,9 +48,25 @@
     "prefer-template": "error",
     "symbol-description": "error",
     "yoda": "error",
+    "unicorn/catch-error-name": ["error", { "name": "err" }],
+    "unicorn/error-message": "error",
+    "unicorn/no-negated-condition": "error",
+    "unicorn/no-useless-promise-resolve-reject": "error",
+    "unicorn/prefer-at": "error",
     "unicorn/prefer-node-protocol": "error",
+    "unicorn/prefer-set-has": "error",
+    "unicorn/throw-new-error": "error",
+    "import/first": "error",
+    "import/no-commonjs": "error",
     "import/no-cycle": "error",
+    "import/no-duplicates": "error",
+    "import/no-mutable-exports": "error",
+    "import/no-self-import": "error",
     "promise/always-return": "off",
+    "promise/no-multiple-resolved": "error",
+    "promise/no-nesting": "error",
+    "promise/no-return-wrap": "error",
+    "promise/param-names": "error",
     "no-underscore-dangle": "off"
   },
   "overrides": [

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,19 @@
+{
+  "file_types": {
+    "JSON": ["**/*.json"]
+  },
+  "languages": {
+    "JavaScript": {
+      "format_on_save": "on",
+      "language_servers": ["typescript-language-server", "oxlint", "oxfmt"],
+      "formatter": {
+        "language_server": {
+          "name": "oxfmt"
+        }
+      },
+      "code_actions_on_format": {
+        "source.fixAll.oxc": true
+      }
+    }
+  }
+}

--- a/lib/client.js
+++ b/lib/client.js
@@ -102,12 +102,10 @@ export class MongoClient {
     await this._connecting;
 
     if (!this.db) {
-      throw new Error('client closed during open');
+      throw new Error('Client closed during open');
     }
 
-    if (!this._cols) {
-      this._cols = new Map();
-    }
+    this._cols ??= new Map();
 
     let col = this._cols.get(name);
     if (!col) {
@@ -137,7 +135,7 @@ export class MongoClient {
   async close() {
     const previous = this._closing;
 
-    const myClose = (async () => {
+    const current = (async () => {
       if (previous) {
         await previous;
       }
@@ -159,12 +157,12 @@ export class MongoClient {
       }
     })();
 
-    this._closing = myClose;
+    this._closing = current;
 
     try {
-      await myClose;
+      await current;
     } finally {
-      if (this._closing === myClose) {
+      if (this._closing === current) {
         this._closing = null;
       }
     }

--- a/lib/client.js
+++ b/lib/client.js
@@ -46,7 +46,7 @@ export class MongoClient {
       const host = server.host || DEFAULT_HOST;
       const port = server.port || DEFAULT_PORT;
 
-      this.url = `mongodb://${host}:${port}/${server.dbname}`;
+      this.url = `mongodb://${host}:${port}/${encodeURIComponent(server.dbname)}`;
     }
 
     this.silent = silent === true;

--- a/lib/client.js
+++ b/lib/client.js
@@ -15,7 +15,8 @@ const DEFAULT_PORT = '27017';
  *
  * - `silent` — suppress all internal logging on swallowed errors
  * - `onError` — replace default `console.error` with a custom handler `(err, ctx)
- *   => void`, where `ctx = {method, collection?, query?}`
+ *   => void`, where `ctx = {method, collection?, query?}`; can also be set per
+ *   operation via `options.onError`, which takes precedence for that call
  *
  * @example
  *   const mongo = new MongoClient({ dbname: 'app' });
@@ -183,10 +184,11 @@ export class MongoClient {
 
     if (this.onError) {
       try {
-        this.onError(err, ctx);
-      } catch {
-        // onError must not break the caller
-      }
+        // Defuses an async handler's rejection; the catch covers sync throws.
+        // The lint rule false-positives on the `err` parameter name.
+        // oxlint-disable-next-line promise/no-promise-in-callback
+        Promise.resolve(this.onError(err, ctx)).catch(() => {});
+      } catch {}
       return;
     }
 
@@ -196,8 +198,6 @@ export class MongoClient {
 
     try {
       console.error(`[easymongo] ${where} failed:`, err);
-    } catch {
-      // console hostile, nothing we can do
-    }
+    } catch {}
   }
 }

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -4,7 +4,8 @@ import { is, isNonEmptyFilter } from './utils.js';
 /**
  * Wrapper around a single MongoDB collection. Public methods are fail-silent:
  * any thrown driver error is reported via the parent client's observability
- * hook and replaced with an empty default.
+ * hook — or via a per-operation `options.onError`, which takes ownership for
+ * that call — and replaced with an empty default.
  */
 export class Collection {
   constructor(client, name) {
@@ -27,8 +28,8 @@ export class Collection {
    * Find documents.
    *
    * @param {object} [query]
-   * @param {object} [options] - { limit, skip, sort, fields, projection, signal
-   *   }
+   * @param {object} [options] - { limit?, skip?, sort?, fields?, projection?,
+   *   signal?, onError? }
    * @returns {Promise<object[]>}
    */
   async find(query, options) {
@@ -39,49 +40,48 @@ export class Collection {
         .find(prepare(query), buildFindOptions(options))
         .toArray();
     } catch (err) {
-      this.client.emit(err, { method: 'find', collection: this.name, query });
+      report(this.client, options, err, {
+        method: 'find',
+        collection: this.name,
+        query
+      });
+
       return [];
     }
   }
 
   /**
-   * Iterate matching documents lazily without materializing them into an array.
-   * The returned object exposes only `Symbol.asyncIterator` and
-   * `Symbol.asyncDispose`, so it composes with `for await` and `await using`
-   * and nothing else.
+   * Iterate matching documents lazily without materializing an array. The
+   * returned object exposes only `Symbol.asyncIterator` and
+   * `Symbol.asyncDispose`, composing with `for await` and `await using`.
    *
-   * The native cursor is opened on first iteration and closed automatically
-   * when iteration ends — naturally, by `break`, or when leaving an `await
-   * using` scope. Errors during open or iteration collapse the loop to an early
-   * end and route through `client.emit`; no exception escapes the `for await`.
+   * The cursor opens on first iteration and closes when iteration ends —
+   * naturally, by `break`, or on `await using` scope exit. Errors collapse the
+   * loop to an early end and route through `options.onError` or `client.emit`;
+   * no exception escapes the `for await`.
    *
-   * The returned object is a factory: each call to `[Symbol.asyncIterator]()`
-   * opens its own cursor, so the same value can be iterated multiple times
-   * sequentially or in parallel. Abandoning an iterator without
-   * `break`/`return`/`await using` delays cursor cleanup until GC; prefer
-   * explicit lifetime management for unbounded queries.
+   * The value is a factory: each `[Symbol.asyncIterator]()` call opens its own
+   * cursor, so it can be iterated repeatedly, sequentially or in parallel.
+   * Abandoning an iterator without `break`/`return`/`await using` delays cursor
+   * cleanup until GC; prefer explicit lifetime management for unbounded
+   * queries.
    *
    * @param {object} [query]
-   * @param {object} [options] - { limit, skip, sort, fields, projection, signal
-   *   }
+   * @param {object} [options] - { limit?, skip?, sort?, fields?, projection?,
+   *   signal?, onError? }
    * @returns {AsyncIterable<object> & AsyncDisposable}
    */
   each(query, options) {
-    return makeIterator(
-      this.client,
-      this.name,
-      query,
-      prepare(query),
-      buildFindOptions(options)
-    );
+    return iterable(this.client, this.name, query, options);
   }
 
   /**
-   * Find a single document.
+   * Find a single document. The driver always fetches a single document here,
+   * so `limit` has no effect and is not part of this method's options.
    *
    * @param {object} [query]
-   * @param {object} [options] - { limit, skip, sort, fields, projection, signal
-   *   }
+   * @param {object} [options] - { skip?, sort?, fields?, projection?, signal?,
+   *   onError? }
    * @returns {Promise<object | null>}
    */
   async findOne(query, options) {
@@ -91,11 +91,12 @@ export class Collection {
 
       return doc ?? null;
     } catch (err) {
-      this.client.emit(err, {
+      report(this.client, options, err, {
         method: 'findOne',
         collection: this.name,
         query
       });
+
       return null;
     }
   }
@@ -116,7 +117,7 @@ export class Collection {
    * Check whether at least one document matches the query.
    *
    * @param {object} [query]
-   * @param {object} [options] - { signal? }
+   * @param {object} [options] - { signal?, onError? }
    * @returns {Promise<boolean>}
    */
   async exists(query, options) {
@@ -129,7 +130,12 @@ export class Collection {
 
       return doc != null;
     } catch (err) {
-      this.client.emit(err, { method: 'exists', collection: this.name, query });
+      report(this.client, options, err, {
+        method: 'exists',
+        collection: this.name,
+        query
+      });
+
       return false;
     }
   }
@@ -151,7 +157,7 @@ export class Collection {
    * recover.
    *
    * @param {object} [query]
-   * @param {object} [options] - { signal? }
+   * @param {object} [options] - { signal?, onError? }
    * @returns {Promise<number>}
    */
   async count(query, options) {
@@ -187,7 +193,12 @@ export class Collection {
         return n;
       }
     } catch (err) {
-      this.client.emit(err, { method: 'count', collection: this.name, query });
+      report(this.client, options, err, {
+        method: 'count',
+        collection: this.name,
+        query
+      });
+
       return 0;
     }
   }
@@ -197,7 +208,7 @@ export class Collection {
    *
    * @param {string} field
    * @param {object} [query]
-   * @param {object} [options] - { signal? }
+   * @param {object} [options] - { signal?, onError? }
    * @returns {Promise<unknown[]>}
    */
   async distinct(field, query, options) {
@@ -212,11 +223,12 @@ export class Collection {
 
       return is.arr(result) ? result : [];
     } catch (err) {
-      this.client.emit(err, {
+      report(this.client, options, err, {
         method: 'distinct',
         collection: this.name,
         query
       });
+
       return [];
     }
   }
@@ -226,7 +238,7 @@ export class Collection {
    * Returns the document with `_id` populated, or null on failure.
    *
    * @param {object} doc
-   * @param {object} [options] - { signal? }
+   * @param {object} [options] - { signal?, onError? }
    * @returns {Promise<object | null>}
    */
   async save(doc, options) {
@@ -264,7 +276,11 @@ export class Collection {
 
       return result.insertedId ? { ...prepared, _id: result.insertedId } : null;
     } catch (err) {
-      this.client.emit(err, { method: 'save', collection: this.name });
+      report(this.client, options, err, {
+        method: 'save',
+        collection: this.name
+      });
+
       return null;
     }
   }
@@ -275,7 +291,7 @@ export class Collection {
    * failure.
    *
    * @param {object[]} docs
-   * @param {object} [options] - { signal? }
+   * @param {object} [options] - { signal?, onError? }
    * @returns {Promise<object[]>}
    */
   async saveAll(docs, options) {
@@ -306,7 +322,11 @@ export class Collection {
         _id: d._id ?? result.insertedIds[idx]
       }));
     } catch (err) {
-      this.client.emit(err, { method: 'saveAll', collection: this.name });
+      report(this.client, options, err, {
+        method: 'saveAll',
+        collection: this.name
+      });
+
       return collectInserted(prepared, err);
     }
   }
@@ -314,28 +334,27 @@ export class Collection {
   /**
    * Update many documents matching the query.
    *
-   * The query must be a non-empty plain object. `null`, `undefined`, and `{}`
-   * are rejected to prevent accidentally rewriting every document in the
-   * collection (for example when a caller forgets to populate a filter
-   * variable).
+   * The query must be a non-empty plain object: `null`, `undefined`, and `{}`
+   * are rejected so a forgotten filter variable cannot rewrite the entire
+   * collection.
    *
-   * `options.arrayFilters` is forwarded to the driver to support positional
-   * filtered updates (e.g. `{ $set: { 'links.$[el].uri': '/new' } }` with
-   * `arrayFilters: [{ 'el.type': 'related' }]`). `options.signal` cancels the
-   * operation. No other driver options are exposed.
+   * `options.arrayFilters` is forwarded for positional filtered updates (e.g.
+   * `{ $set: { 'links.$[el].uri': '/new' } }` with `arrayFilters: [{ 'el.type':
+   * 'related' }]`). No other driver options are exposed.
    *
    * @param {object} query
    * @param {object} update - Mongo update operators (e.g. {$set: {...}})
-   * @param {object} [options] - { arrayFilters?, signal? }
+   * @param {object} [options] - { arrayFilters?, signal?, onError? }
    * @returns {Promise<boolean>} True if at least one document was modified
    */
   async update(query, update, options) {
     if (!isNonEmptyFilter(query)) {
-      this.client.emit(new Error('empty filter rejected'), {
+      report(this.client, options, new Error('Empty filter rejected'), {
         method: 'update',
         collection: this.name,
         query
       });
+
       return false;
     }
 
@@ -349,7 +368,12 @@ export class Collection {
 
       return result.modifiedCount > 0;
     } catch (err) {
-      this.client.emit(err, { method: 'update', collection: this.name, query });
+      report(this.client, options, err, {
+        method: 'update',
+        collection: this.name,
+        query
+      });
+
       return false;
     }
   }
@@ -357,20 +381,21 @@ export class Collection {
   /**
    * Delete many documents matching the query.
    *
-   * The query must be a non-empty plain object. `null`, `undefined`, and `{}`
-   * are rejected to prevent accidentally wiping the collection.
+   * The query must be a non-empty plain object: `null`, `undefined`, and `{}`
+   * are rejected so a forgotten filter variable cannot wipe the collection.
    *
    * @param {object} query
-   * @param {object} [options] - { signal? }
+   * @param {object} [options] - { signal?, onError? }
    * @returns {Promise<boolean>} True if at least one document was deleted
    */
   async remove(query, options) {
     if (!isNonEmptyFilter(query)) {
-      this.client.emit(new Error('empty filter rejected'), {
+      report(this.client, options, new Error('Empty filter rejected'), {
         method: 'remove',
         collection: this.name,
         query
       });
+
       return false;
     }
 
@@ -383,7 +408,12 @@ export class Collection {
 
       return result.deletedCount > 0;
     } catch (err) {
-      this.client.emit(err, { method: 'remove', collection: this.name, query });
+      report(this.client, options, err, {
+        method: 'remove',
+        collection: this.name,
+        query
+      });
+
       return false;
     }
   }
@@ -392,7 +422,7 @@ export class Collection {
    * Delete a single document by id.
    *
    * @param {unknown} id
-   * @param {object} [options] - { signal? }
+   * @param {object} [options] - { signal?, onError? }
    * @returns {Promise<boolean>}
    */
   async removeById(id, options) {
@@ -405,11 +435,12 @@ export class Collection {
 
       return result.deletedCount > 0;
     } catch (err) {
-      this.client.emit(err, {
+      report(this.client, options, err, {
         method: 'removeById',
         collection: this.name,
         query: { _id: id }
       });
+
       return false;
     }
   }
@@ -417,44 +448,48 @@ export class Collection {
   /**
    * Create a single index. Returns the index name on success, or null on
    * failure. Conflicts with an existing index of a different shape are reported
-   * via `client.emit` and collapsed to null (no recreate).
+   * via the per-operation `onError` or the client hook and collapsed to null
+   * (no recreate).
    *
    * @param {object | string | Array} spec - Mongo index specification
-   * @param {object} [options] - Mongo index options (e.g. { unique: true })
+   * @param {object} [options] - Mongo index options (e.g. { unique: true }),
+   *   plus the wrapper-only `onError`
    * @returns {Promise<string | null>}
    */
   async createIndex(spec, options) {
     if (!is.obj(spec) && !is.str(spec) && !is.arr(spec)) {
-      this.client.emit(new Error('invalid index spec'), {
+      report(this.client, options, new Error('Invalid index spec rejected'), {
         method: 'createIndex',
         collection: this.name
       });
+
       return null;
     }
 
     try {
       const col = await this.client.open(this.name);
-      return await col.createIndex(spec, options);
+
+      return await col.createIndex(spec, indexOptions(options));
     } catch (err) {
-      this.client.emit(err, {
+      report(this.client, options, err, {
         method: 'createIndex',
         collection: this.name
       });
+
       return null;
     }
   }
 
   /**
-   * Idempotently create a list of indexes. Each entry is `{ key, options? }`.
-   * Conflicts (same key, incompatible options) are reported and skipped — the
-   * loop continues. Returns the names of successfully created or
-   * already-present indexes.
+   * Idempotently create a list of indexes. Each entry is `{ key, options? }`;
+   * returns the names of created or already-present indexes.
    *
-   * Entries are processed sequentially in order, so when two entries in the
-   * same call target the same key with different options, the **first one
-   * wins**: it succeeds, and the rest collapse to a conflict + `client.emit`
-   * and are skipped. Running them in parallel would race and leave the
-   * collection with a nondeterministic index shape.
+   * Entries are processed sequentially: on an intra-call conflict (same key,
+   * different options) the first entry wins, the rest are reported and skipped.
+   * Parallel execution would leave a nondeterministic index shape.
+   *
+   * Entry `options` pass through `createIndex` unchanged, so the wrapper-only
+   * `onError` applies per entry.
    *
    * @param {{ key: object | string | Array; options?: object }[]} specs
    * @returns {Promise<string[]>}
@@ -479,22 +514,21 @@ export class Collection {
   }
 }
 
-function makeIterator(
-  client,
-  name,
-  originalQuery,
-  preparedQuery,
-  driverOptions
-) {
+function iterable(client, name, query, options) {
   const active = new Set();
 
   async function dispose() {
     const cursors = [...active];
+
     active.clear();
+
     const results = await Promise.allSettled(cursors.map((c) => c.close()));
     for (const r of results) {
       if (r.status === 'rejected') {
-        client.emit(r.reason, { method: 'each.close', collection: name });
+        report(client, options, r.reason, {
+          method: 'each.close',
+          collection: name
+        });
       }
     }
   }
@@ -502,32 +536,74 @@ function makeIterator(
   return {
     async *[Symbol.asyncIterator]() {
       let native = null;
+
       try {
         const col = await client.open(name);
-        native = col.find(preparedQuery, driverOptions);
+        native = col.find(prepare(query), buildFindOptions(options));
+
         active.add(native);
+
         for await (const doc of native) {
           yield doc;
         }
       } catch (err) {
-        client.emit(err, {
+        report(client, options, err, {
           method: 'each',
           collection: name,
-          query: originalQuery
+          query
         });
       } finally {
         if (native) {
           active.delete(native);
+
           try {
             await native.close();
           } catch (err) {
-            client.emit(err, { method: 'each.close', collection: name });
+            report(client, options, err, {
+              method: 'each.close',
+              collection: name
+            });
           }
         }
       }
     },
     [Symbol.asyncDispose]: dispose
   };
+}
+
+// Routes a swallowed error to the per-operation handler, else the client hook.
+// A local handler takes ownership: the client path is bypassed and `silent`
+// does not apply. Sync throws are swallowed and async rejections defused — a
+// broken reporter cannot take down the caller.
+function report(client, options, err, ctx) {
+  let local = null;
+
+  try {
+    local = is.obj(options) ? options.onError : null;
+  } catch {}
+
+  if (is.fun(local)) {
+    try {
+      Promise.resolve(local(err, ctx)).catch(() => {});
+    } catch {}
+
+    return;
+  }
+
+  client.emit(err, ctx);
+}
+
+// Index options reach the driver as-is, so the wrapper-only `onError` is
+// stripped.
+function indexOptions(options) {
+  if (!is.obj(options)) {
+    return undefined;
+  }
+
+  const driverOpts = { ...options };
+  delete driverOpts.onError;
+
+  return Object.keys(driverOpts).length ? driverOpts : undefined;
 }
 
 function buildUpdateOptions(options) {

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -14,8 +14,8 @@ export class Collection {
   }
 
   /**
-   * Helper: coerce a value to ObjectId. With no argument, returns a fresh one.
-   * Returns the input untouched if it can't be coerced.
+   * Coerce a value to ObjectId. With no argument, returns a fresh one. Returns
+   * the input untouched if it can't be coerced.
    *
    * @param {unknown} [value]
    * @returns {import('mongodb').ObjectId | unknown}

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -765,7 +765,7 @@ function projectionOf(options) {
   if (is.arr(fields)) {
     const out = Object.create(null);
     for (const f of fields) {
-      if (typeof f === 'string') {
+      if (typeof f === 'string' && f !== '__proto__') {
         out[f] = 1;
       }
     }

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -100,14 +100,29 @@ export class Collection {
   }
 
   /**
-   * Find a single document by id. The id may be a string, ObjectId, or any
-   * value accepted by `prepareId`.
+   * Find a single document by id: a string, ObjectId, or any other scalar BSON
+   * id type.
+   *
+   * Nullish and plain-object ids are rejected (reported, resolved to null): a
+   * nullish id would serialize to `_id: null`, and a plain object is operator
+   * smuggling from request input (`{$ne: null}` matches an arbitrary document).
+   * Use `findOne({_id: {...}})` for intentional operator queries.
    *
    * @param {unknown} id
    * @param {string[] | object} [fields]
    * @returns {Promise<object | null>}
    */
   async findById(id, fields) {
+    if (id == null || is.obj(id)) {
+      report(this.client, undefined, new Error('Invalid id rejected'), {
+        method: 'findById',
+        collection: this.name,
+        query: { _id: id }
+      });
+
+      return null;
+    }
+
     return this.findOne({ _id: id }, fields ? { fields } : undefined);
   }
 
@@ -229,7 +244,13 @@ export class Collection {
 
   /**
    * Insert a new document or replace an existing one (when `_id` is set).
-   * Returns the document with `_id` populated, or null on failure.
+   * Returns the document with `_id` populated, or null on failure. Non-object
+   * input is rejected (reported, resolved to null).
+   *
+   * The document goes through the same `id` alias normalization as queries: a
+   * top-level `id` field is renamed to `_id` (and a 24-char hex string is
+   * coerced to ObjectId). Documents that need a literal `id` data field should
+   * nest it or use a different name.
    *
    * @param {object} doc
    * @param {object} [options] - { signal?, timeout?, onError? }
@@ -237,6 +258,11 @@ export class Collection {
    */
   async save(doc, options) {
     if (!is.obj(doc)) {
+      report(this.client, options, new Error('Invalid document rejected'), {
+        method: 'save',
+        collection: this.name
+      });
+
       return null;
     }
 
@@ -276,9 +302,13 @@ export class Collection {
   }
 
   /**
-   * Insert many documents in one call. Non-object entries are silently dropped.
-   * Returns the inserted documents with their `_id` populated, or [] on
-   * failure.
+   * Insert many documents in one unordered `insertMany`. Returns the inserted
+   * documents with their `_id` populated; on partial failure (e.g. a duplicate
+   * key) only the successfully inserted subset, [] when nothing was inserted.
+   *
+   * Non-array input is rejected (reported, resolved to []); non-object entries
+   * are silently dropped. Each document gets the same `id` → `_id` alias
+   * normalization as `save`.
    *
    * @param {object[]} docs
    * @param {object} [options] - { signal?, timeout?, onError? }
@@ -286,6 +316,11 @@ export class Collection {
    */
   async saveAll(docs, options) {
     if (!is.arr(docs)) {
+      report(this.client, options, new Error('Invalid documents rejected'), {
+        method: 'saveAll',
+        collection: this.name
+      });
+
       return [];
     }
 
@@ -411,11 +446,25 @@ export class Collection {
   /**
    * Delete a single document by id.
    *
+   * Nullish and plain-object ids are rejected (reported, resolved to false) —
+   * same contract as `findById`; `removeById({$ne: null})` from unvalidated
+   * request input would delete an arbitrary document.
+   *
    * @param {unknown} id
    * @param {object} [options] - { signal?, timeout?, onError? }
    * @returns {Promise<boolean>}
    */
   async removeById(id, options) {
+    if (id == null || is.obj(id)) {
+      report(this.client, options, new Error('Invalid id rejected'), {
+        method: 'removeById',
+        collection: this.name,
+        query: { _id: id }
+      });
+
+      return false;
+    }
+
     try {
       const col = await this.client.open(this.name);
       const result = await col.deleteOne(

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -156,18 +156,16 @@ export class Collection {
   /**
    * Count documents matching the query.
    *
-   * An empty / missing query short-circuits to `estimatedDocumentCount`, which
-   * reads the cached collection size without scanning. Numbers may drift on
-   * sharded collections with orphans or after an unclean shutdown, but the path
-   * is roughly two orders of magnitude faster.
+   * An empty/missing query short-circuits to `estimatedDocumentCount`: cached
+   * collection size, no scan; may drift on sharded clusters or after an unclean
+   * shutdown.
    *
-   * For non-empty filters, `countDocuments` builds an aggregation pipeline and
-   * rejects operators that are valid in `find` but disallowed in `$match`
-   * (notably `$where` and `$near`). When that happens we fall back to streaming
-   * the matching ids through the driver cursor and counting in place. Memory
-   * stays bounded (one batch at a time, `_id`-only projection) so a broad
-   * predicate over a large collection cannot OOM before the outer catch can
-   * recover.
+   * Non-empty filters use `countDocuments`, which rejects operators disallowed
+   * in `$match` (`$where`, `$near`). Only that error class — `BadValue` or a
+   * `Location*` uassert — triggers the fallback: streaming `_id`s through a
+   * cursor and counting in place, one batch at a time. Network, timeout, abort,
+   * and auth errors are not retried via the fallback (a full scan is the worst
+   * response to a struggling server); they collapse to 0.
    *
    * @param {object} [query]
    * @param {object} [options] - { signal?, timeout?, onError? }
@@ -185,7 +183,14 @@ export class Collection {
 
       try {
         return await col.countDocuments(prepared, attach(undefined, signal));
-      } catch {
+      } catch (err) {
+        const unsupported =
+          err?.name === 'MongoServerError' &&
+          (err.code === 2 || String(err.codeName).startsWith('Location'));
+        if (!unsupported) {
+          throw err;
+        }
+
         const cursor = col.find(
           prepared,
           attach({ projection: { _id: 1 } }, signal)

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -29,16 +29,14 @@ export class Collection {
    *
    * @param {object} [query]
    * @param {object} [options] - { limit?, skip?, sort?, fields?, projection?,
-   *   signal?, onError? }
+   *   signal?, timeout?, onError? }
    * @returns {Promise<object[]>}
    */
   async find(query, options) {
     try {
       const col = await this.client.open(this.name);
 
-      return await col
-        .find(prepare(query), buildFindOptions(options))
-        .toArray();
+      return await col.find(prepare(query), findOptions(options)).toArray();
     } catch (err) {
       report(this.client, options, err, {
         method: 'find',
@@ -68,7 +66,7 @@ export class Collection {
    *
    * @param {object} [query]
    * @param {object} [options] - { limit?, skip?, sort?, fields?, projection?,
-   *   signal?, onError? }
+   *   signal?, timeout?, onError? }
    * @returns {AsyncIterable<object> & AsyncDisposable}
    */
   each(query, options) {
@@ -81,13 +79,13 @@ export class Collection {
    *
    * @param {object} [query]
    * @param {object} [options] - { skip?, sort?, fields?, projection?, signal?,
-   *   onError? }
+   *   timeout?, onError? }
    * @returns {Promise<object | null>}
    */
   async findOne(query, options) {
     try {
       const col = await this.client.open(this.name);
-      const doc = await col.findOne(prepare(query), buildFindOptions(options));
+      const doc = await col.findOne(prepare(query), findOptions(options));
 
       return doc ?? null;
     } catch (err) {
@@ -117,7 +115,7 @@ export class Collection {
    * Check whether at least one document matches the query.
    *
    * @param {object} [query]
-   * @param {object} [options] - { signal?, onError? }
+   * @param {object} [options] - { signal?, timeout?, onError? }
    * @returns {Promise<boolean>}
    */
   async exists(query, options) {
@@ -157,7 +155,7 @@ export class Collection {
    * recover.
    *
    * @param {object} [query]
-   * @param {object} [options] - { signal?, onError? }
+   * @param {object} [options] - { signal?, timeout?, onError? }
    * @returns {Promise<number>}
    */
   async count(query, options) {
@@ -167,21 +165,17 @@ export class Collection {
       const signal = signalOf(options);
 
       if (Object.keys(prepared).length === 0) {
-        return await col.estimatedDocumentCount(
-          signal ? { signal } : undefined
-        );
+        return await col.estimatedDocumentCount(attach(undefined, signal));
       }
 
       try {
-        return await col.countDocuments(
-          prepared,
-          signal ? { signal } : undefined
-        );
+        return await col.countDocuments(prepared, attach(undefined, signal));
       } catch {
-        const cursorOpts = signal
-          ? { projection: { _id: 1 }, signal }
-          : { projection: { _id: 1 } };
-        const cursor = col.find(prepared, cursorOpts);
+        const cursor = col.find(
+          prepared,
+          attach({ projection: { _id: 1 } }, signal)
+        );
+
         let n = 0;
         try {
           for await (const _doc of cursor) {
@@ -190,6 +184,7 @@ export class Collection {
         } finally {
           await cursor.close();
         }
+
         return n;
       }
     } catch (err) {
@@ -208,17 +203,16 @@ export class Collection {
    *
    * @param {string} field
    * @param {object} [query]
-   * @param {object} [options] - { signal?, onError? }
+   * @param {object} [options] - { signal?, timeout?, onError? }
    * @returns {Promise<unknown[]>}
    */
   async distinct(field, query, options) {
     try {
       const col = await this.client.open(this.name);
-      const signal = signalOf(options);
       const result = await col.distinct(
         field,
         prepare(query),
-        signal ? { signal } : undefined
+        withSignal(undefined, options)
       );
 
       return is.arr(result) ? result : [];
@@ -238,7 +232,7 @@ export class Collection {
    * Returns the document with `_id` populated, or null on failure.
    *
    * @param {object} doc
-   * @param {object} [options] - { signal?, onError? }
+   * @param {object} [options] - { signal?, timeout?, onError? }
    * @returns {Promise<object | null>}
    */
   async save(doc, options) {
@@ -249,16 +243,12 @@ export class Collection {
     try {
       const col = await this.client.open(this.name);
       const prepared = prepare(doc);
-      const signal = signalOf(options);
 
       if (prepared._id != null) {
-        const replaceOpts = signal
-          ? { upsert: true, signal }
-          : { upsert: true };
         const result = await col.replaceOne(
           { _id: prepared._id },
           prepared,
-          replaceOpts
+          withSignal({ upsert: true }, options)
         );
 
         const touched =
@@ -271,7 +261,7 @@ export class Collection {
 
       const result = await col.insertOne(
         prepared,
-        signal ? { signal } : undefined
+        withSignal(undefined, options)
       );
 
       return result.insertedId ? { ...prepared, _id: result.insertedId } : null;
@@ -291,7 +281,7 @@ export class Collection {
    * failure.
    *
    * @param {object[]} docs
-   * @param {object} [options] - { signal?, onError? }
+   * @param {object} [options] - { signal?, timeout?, onError? }
    * @returns {Promise<object[]>}
    */
   async saveAll(docs, options) {
@@ -344,7 +334,7 @@ export class Collection {
    *
    * @param {object} query
    * @param {object} update - Mongo update operators (e.g. {$set: {...}})
-   * @param {object} [options] - { arrayFilters?, signal?, onError? }
+   * @param {object} [options] - { arrayFilters?, signal?, timeout?, onError? }
    * @returns {Promise<boolean>} True if at least one document was modified
    */
   async update(query, update, options) {
@@ -363,7 +353,7 @@ export class Collection {
       const result = await col.updateMany(
         prepare(query),
         update,
-        buildUpdateOptions(options)
+        updateOptions(options)
       );
 
       return result.modifiedCount > 0;
@@ -385,7 +375,7 @@ export class Collection {
    * are rejected so a forgotten filter variable cannot wipe the collection.
    *
    * @param {object} query
-   * @param {object} [options] - { signal?, onError? }
+   * @param {object} [options] - { signal?, timeout?, onError? }
    * @returns {Promise<boolean>} True if at least one document was deleted
    */
   async remove(query, options) {
@@ -422,7 +412,7 @@ export class Collection {
    * Delete a single document by id.
    *
    * @param {unknown} id
-   * @param {object} [options] - { signal?, onError? }
+   * @param {object} [options] - { signal?, timeout?, onError? }
    * @returns {Promise<boolean>}
    */
   async removeById(id, options) {
@@ -453,7 +443,7 @@ export class Collection {
    *
    * @param {object | string | Array} spec - Mongo index specification
    * @param {object} [options] - Mongo index options (e.g. { unique: true }),
-   *   plus the wrapper-only `onError`
+   *   plus the wrapper-only `onError`, `signal`, and `timeout`
    * @returns {Promise<string | null>}
    */
   async createIndex(spec, options) {
@@ -489,7 +479,7 @@ export class Collection {
    * Parallel execution would leave a nondeterministic index shape.
    *
    * Entry `options` pass through `createIndex` unchanged, so the wrapper-only
-   * `onError` applies per entry.
+   * `onError`, `signal`, and `timeout` apply per entry.
    *
    * @param {{ key: object | string | Array; options?: object }[]} specs
    * @returns {Promise<string[]>}
@@ -539,7 +529,7 @@ function iterable(client, name, query, options) {
 
       try {
         const col = await client.open(name);
-        native = col.find(prepare(query), buildFindOptions(options));
+        native = col.find(prepare(query), findOptions(options));
 
         active.add(native);
 
@@ -593,8 +583,9 @@ function report(client, options, err, ctx) {
   client.emit(err, ctx);
 }
 
-// Index options reach the driver as-is, so the wrapper-only `onError` is
-// stripped.
+// Index options reach the driver as-is, so the wrapper-only `onError` and
+// `timeout` are stripped; the resolved signal is forwarded (the driver's typed
+// API omits `signal` on index operations, the runtime honors it).
 function indexOptions(options) {
   if (!is.obj(options)) {
     return undefined;
@@ -602,11 +593,15 @@ function indexOptions(options) {
 
   const driverOpts = { ...options };
   delete driverOpts.onError;
+  delete driverOpts.timeout;
 
-  return Object.keys(driverOpts).length ? driverOpts : undefined;
+  return attach(
+    Object.keys(driverOpts).length ? driverOpts : undefined,
+    signalOf(options)
+  );
 }
 
-function buildUpdateOptions(options) {
+function updateOptions(options) {
   if (!is.obj(options)) {
     return undefined;
   }
@@ -615,20 +610,18 @@ function buildUpdateOptions(options) {
   if (is.arr(options.arrayFilters)) {
     out.arrayFilters = options.arrayFilters;
   }
-  if (options.signal) {
-    out.signal = options.signal;
-  }
 
-  return Object.keys(out).length ? out : undefined;
+  return withSignal(Object.keys(out).length ? out : undefined, options);
 }
 
-function buildFindOptions(options) {
+function findOptions(options) {
   if (!is.obj(options)) {
     return undefined;
   }
 
   const out = {};
   const projection = normalizeProjection(options);
+
   if (projection) {
     out.projection = projection;
   }
@@ -641,23 +634,34 @@ function buildFindOptions(options) {
   if (options.sort) {
     out.sort = options.sort;
   }
-  if (options.signal) {
-    out.signal = options.signal;
-  }
 
-  return Object.keys(out).length ? out : undefined;
+  return withSignal(Object.keys(out).length ? out : undefined, options);
 }
 
+// Resolves a caller signal and `options.timeout` (ms) into one AbortSignal:
+// the operation aborts when either fires. The composite is per-operation and
+// unreferenced once the call settles.
 function signalOf(options) {
-  return is.obj(options) ? options.signal : undefined;
+  if (!is.obj(options)) {
+    return undefined;
+  }
+
+  const { signal, timeout } = options;
+  if (Number.isFinite(timeout) && timeout > 0) {
+    const deadline = AbortSignal.timeout(timeout);
+
+    return signal ? AbortSignal.any([signal, deadline]) : deadline;
+  }
+
+  return signal;
 }
 
 function withSignal(driverOpts, options) {
-  const signal = signalOf(options);
-  if (!signal) {
-    return driverOpts;
-  }
-  return { ...driverOpts, signal };
+  return attach(driverOpts, signalOf(options));
+}
+
+function attach(driverOpts, signal) {
+  return signal ? { ...driverOpts, signal } : driverOpts;
 }
 
 function normalizeProjection(options) {

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -675,7 +675,7 @@ function findOptions(options) {
   }
 
   const out = {};
-  const projection = normalizeProjection(options);
+  const projection = projectionOf(options);
 
   if (projection) {
     out.projection = projection;
@@ -719,21 +719,21 @@ function attach(driverOpts, signal) {
   return signal ? { ...driverOpts, signal } : driverOpts;
 }
 
-function normalizeProjection(options) {
+function projectionOf(options) {
   if (is.obj(options.projection)) {
     return options.projection;
   }
 
   const { fields } = options;
   if (is.arr(fields)) {
-    const out = {};
+    const out = Object.create(null);
     for (const f of fields) {
       if (typeof f === 'string') {
         out[f] = 1;
       }
     }
 
-    return Object.keys(out).length ? out : undefined;
+    return Object.keys(out).length ? out : { _id: 1 };
   }
 
   if (is.obj(fields)) {

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -29,7 +29,7 @@ export class Collection {
    *
    * @param {object} [query]
    * @param {object} [options] - { limit?, skip?, sort?, fields?, projection?,
-   *   signal?, timeout?, onError? }
+   *   batchSize?, signal?, timeout?, onError? }
    * @returns {Promise<object[]>}
    */
   async find(query, options) {
@@ -65,7 +65,7 @@ export class Collection {
    *
    * @param {object} [query]
    * @param {object} [options] - { limit?, skip?, sort?, fields?, projection?,
-   *   signal?, timeout?, onError? }
+   *   batchSize?, signal?, timeout?, onError? }
    * @returns {AsyncIterable<object> & AsyncDisposable}
    */
   each(query, options) {
@@ -722,6 +722,9 @@ function findOptions(options) {
   }
   if (options.sort) {
     out.sort = options.sort;
+  }
+  if (Number.isFinite(options.batchSize)) {
+    out.batchSize = options.batchSize;
   }
 
   return withSignal(Object.keys(out).length ? out : undefined, options);

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1,5 +1,5 @@
 import { prepare, prepareId } from './prepare.js';
-import { is, isNonEmptyFilter } from './utils.js';
+import { is } from './utils.js';
 
 /**
  * Wrapper around a single MongoDB collection. Public methods are fail-silent:
@@ -325,34 +325,36 @@ export class Collection {
     }
 
     const prepared = [];
-    for (const doc of docs) {
-      if (is.obj(doc)) {
-        prepared.push(prepare(doc));
-      }
-    }
-
-    if (prepared.length === 0) {
-      return [];
-    }
 
     try {
+      for (const doc of docs) {
+        if (is.obj(doc)) {
+          prepared.push(prepare(doc));
+        }
+      }
+
+      if (prepared.length === 0) {
+        return [];
+      }
+
       const col = await this.client.open(this.name);
       const result = await col.insertMany(
         prepared,
         withSignal({ ordered: false }, options)
       );
 
-      return prepared.map((d, idx) => ({
-        ...d,
-        _id: d._id ?? result.insertedIds[idx]
-      }));
+      for (const [idx, d] of prepared.entries()) {
+        d._id ??= result.insertedIds[idx];
+      }
+
+      return prepared;
     } catch (err) {
       report(this.client, options, err, {
         method: 'saveAll',
         collection: this.name
       });
 
-      return collectInserted(prepared, err);
+      return recover(prepared, err);
     }
   }
 
@@ -373,7 +375,7 @@ export class Collection {
    * @returns {Promise<boolean>} True if at least one document was modified
    */
   async update(query, update, options) {
-    if (!isNonEmptyFilter(query)) {
+    if (!is.filter(query)) {
       report(this.client, options, new Error('Empty filter rejected'), {
         method: 'update',
         collection: this.name,
@@ -414,7 +416,7 @@ export class Collection {
    * @returns {Promise<boolean>} True if at least one document was deleted
    */
   async remove(query, options) {
-    if (!isNonEmptyFilter(query)) {
+    if (!is.filter(query)) {
       report(this.client, options, new Error('Empty filter rejected'), {
         method: 'remove',
         collection: this.name,
@@ -540,15 +542,19 @@ export class Collection {
 
     const out = [];
     for (const item of specs) {
-      if (!is.obj(item) || item.key == null) {
-        continue;
-      }
-      // oxlint-disable-next-line no-await-in-loop
-      const name = await this.createIndex(item.key, item.options);
+      let name = null;
+      try {
+        if (is.obj(item) && item.key != null) {
+          // oxlint-disable-next-line no-await-in-loop
+          name = await this.createIndex(item.key, item.options);
+        }
+      } catch {}
+
       if (name) {
         out.push(name);
       }
     }
+
     return out;
   }
 }
@@ -737,8 +743,13 @@ function normalizeProjection(options) {
   return undefined;
 }
 
-function collectInserted(prepared, err) {
-  const ids = err?.insertedIds;
+function recover(prepared, err) {
+  let ids = null;
+
+  try {
+    ids = err?.insertedIds;
+  } catch {}
+
   if (!ids) {
     return [];
   }

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -59,10 +59,9 @@ export class Collection {
    * no exception escapes the `for await`.
    *
    * The value is a factory: each `[Symbol.asyncIterator]()` call opens its own
-   * cursor, so it can be iterated repeatedly, sequentially or in parallel.
-   * Abandoning an iterator without `break`/`return`/`await using` delays cursor
-   * cleanup until GC; prefer explicit lifetime management for unbounded
-   * queries.
+   * cursor, so it can be iterated repeatedly, sequentially or in parallel. An
+   * abandoned iterator releases its cursor only when GC collects it; prefer
+   * explicit lifetime management for unbounded queries.
    *
    * @param {object} [query]
    * @param {object} [options] - { limit?, skip?, sort?, fields?, projection?,
@@ -564,8 +563,63 @@ export class Collection {
   }
 }
 
+// Closes cursors of iterators abandoned without `break`/`return`/`await using`
+// once GC collects them — the driver pins unfinished cursors until
+// `client.close()`. Holds the iterator weakly and the state strongly; a clean
+// `finally` unregisters, so the callback never fires for finished iterations.
+const registry = new FinalizationRegistry((state) => {
+  const { native } = state;
+
+  if (native) {
+    state.active.delete(native);
+    state.native = null;
+
+    native.close().catch((err) => {
+      report(state.client, state.options, err, {
+        method: 'each.close',
+        collection: state.name
+      });
+    });
+  }
+});
+
 function iterable(client, name, query, options) {
   const active = new Set();
+
+  async function* run(state) {
+    let native = null;
+
+    try {
+      const col = await client.open(name);
+      native = col.find(prepare(query), findOptions(options));
+
+      state.native = native;
+      active.add(native);
+
+      for await (const doc of native) {
+        yield doc;
+      }
+    } catch (err) {
+      report(client, options, err, { method: 'each', collection: name, query });
+    } finally {
+      registry.unregister(state);
+
+      state.native = null;
+
+      if (native) {
+        active.delete(native);
+
+        try {
+          await native.close();
+        } catch (err) {
+          report(client, options, err, {
+            method: 'each.close',
+            collection: name
+          });
+        }
+      }
+    }
+  }
 
   async function dispose() {
     const cursors = [...active];
@@ -584,38 +638,13 @@ function iterable(client, name, query, options) {
   }
 
   return {
-    async *[Symbol.asyncIterator]() {
-      let native = null;
+    [Symbol.asyncIterator]() {
+      const state = { client, name, active, native: null, options };
 
-      try {
-        const col = await client.open(name);
-        native = col.find(prepare(query), findOptions(options));
+      const iterator = run(state);
+      registry.register(iterator, state, state);
 
-        active.add(native);
-
-        for await (const doc of native) {
-          yield doc;
-        }
-      } catch (err) {
-        report(client, options, err, {
-          method: 'each',
-          collection: name,
-          query
-        });
-      } finally {
-        if (native) {
-          active.delete(native);
-
-          try {
-            await native.close();
-          } catch (err) {
-            report(client, options, err, {
-              method: 'each.close',
-              collection: name
-            });
-          }
-        }
-      }
+      return iterator;
     },
     [Symbol.asyncDispose]: dispose
   };

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -3,9 +3,12 @@ import { ObjectId } from 'mongodb';
 import { is } from './utils.js';
 
 /**
- * Coerce a value into an ObjectId. - undefined/null → fresh ObjectId - string →
- * ObjectId(string) when the string is a valid 24-char hex - anything else
- * (including an existing ObjectId or invalid string) → returned as-is
+ * Coerce a value into an ObjectId.
+ *
+ * - Undefined/null → fresh ObjectId
+ * - String → ObjectId(string) when the string is a valid 24-char hex
+ * - Anything else (including an existing ObjectId or invalid string) → returned
+ *   as-is
  *
  * @param {unknown} value
  * @returns {ObjectId | unknown}
@@ -46,8 +49,9 @@ const SCALAR_OPERATORS = ['$eq', '$ne', '$gt', '$gte', '$lt', '$lte'];
  * removed when `_id` is present (either directly or via alias), so it never
  * leaks into the driver query as a literal field.
  *
- * @param {object | null | undefined} params
- * @returns {object}
+ * @param {unknown} params
+ * @returns {object | unknown} A new object for plain-object/nullish input;
+ *   anything else is returned as-is
  */
 export function prepare(params) {
   if (params === undefined || params === null) {
@@ -72,12 +76,12 @@ export function prepare(params) {
   }
   delete out.id;
 
-  out._id = coerceIdValue(out._id);
+  out._id = coerceId(out._id);
 
   return out;
 }
 
-function coerceIdValue(value) {
+function coerceId(value) {
   if (!is.obj(value)) {
     return prepareId(value);
   }
@@ -93,8 +97,9 @@ function coerceIdValue(value) {
 
   for (const op of SCALAR_OPERATORS) {
     if (op in value) {
-      const coerced = coerceIdScalar(value[op]);
-      if (coerced !== value[op]) {
+      const scalar = value[op];
+      const coerced = scalar == null ? scalar : prepareId(scalar);
+      if (coerced !== scalar) {
         out ??= { ...value };
         out[op] = coerced;
       }
@@ -102,12 +107,4 @@ function coerceIdValue(value) {
   }
 
   return out ?? value;
-}
-
-function coerceIdScalar(value) {
-  if (is.str(value) && ObjectId.isValid(value)) {
-    return new ObjectId(value);
-  }
-
-  return value;
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,21 +1,33 @@
 const fun = (f) => typeof f === 'function';
 const str = (s) => typeof s === 'string';
-const arr = (a) => Array.isArray(a);
-const obj = (o) =>
-  o !== null &&
-  typeof o === 'object' &&
-  Object.getPrototypeOf(o) === Object.prototype;
 
-export const is = { fun, str, arr, obj };
+const arr = (a) => {
+  try {
+    return Array.isArray(a);
+  } catch {
+    return false;
+  }
+};
 
-/**
- * True when `q` is a plain object with at least one own enumerable key. Used by
- * `update` and `remove` to reject empty/missing filters that would otherwise
- * hit every document in the collection.
- *
- * @param {unknown} q
- * @returns {boolean}
- */
-export function isNonEmptyFilter(q) {
-  return is.obj(q) && Object.keys(q).length > 0;
-}
+const obj = (o) => {
+  if (o === null || typeof o !== 'object') {
+    return false;
+  }
+
+  try {
+    const proto = Object.getPrototypeOf(o);
+    return proto === Object.prototype || proto === null;
+  } catch {
+    return false;
+  }
+};
+
+const filter = (q) => {
+  try {
+    return obj(q) && Object.values(q).some((v) => v !== undefined);
+  } catch {
+    return false;
+  }
+};
+
+export const is = { fun, str, arr, obj, filter };

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "coverage": "mkdir -p coverage && node --expose-gc --test --experimental-test-coverage --test-coverage-lines=97 --test-coverage-branches=93 --test-coverage-functions=93 --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info test/*.js"
   },
   "dependencies": {
-    "mongodb": "^7.2"
+    "mongodb": "^7.3.0"
   },
   "devDependencies": {
     "oxfmt": "^0.54.0",
@@ -41,5 +41,5 @@
   "engines": {
     "node": ">=24.16"
   },
-  "packageManager": "pnpm@11.5.2"
+  "packageManager": "pnpm@11.5.3"
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lib"
   ],
   "type": "module",
+  "sideEffects": false,
   "exports": "./lib/index.js",
   "scripts": {
     "lint": "oxlint",
@@ -34,10 +35,11 @@
     "mongodb": "^7.2"
   },
   "devDependencies": {
-    "oxfmt": "^0.47.0",
-    "oxlint": "^1.62.0"
+    "oxfmt": "^0.54.0",
+    "oxlint": "^1.69.0"
   },
   "engines": {
-    "node": ">=24.14"
-  }
+    "node": ">=24.16"
+  },
+  "packageManager": "pnpm@11.5.2"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easymongo",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "Thin, opinionated wrapper around the MongoDB Node.js driver with a fail-silent promise API.",
   "keywords": [
     "easymongo",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "format": "oxfmt",
     "format:check": "oxfmt --check",
     "test": "node --test test/*.js",
-    "coverage": "mkdir -p coverage && node --test --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=coverage/lcov.info test/*.js"
+    "coverage": "mkdir -p coverage && node --test --experimental-test-coverage --test-coverage-lines=97 --test-coverage-branches=93 --test-coverage-functions=93 --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info test/*.js"
   },
   "dependencies": {
     "mongodb": "^7.2"

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "lint": "oxlint",
     "format": "oxfmt",
     "format:check": "oxfmt --check",
-    "test": "node --test test/*.js",
-    "coverage": "mkdir -p coverage && node --test --experimental-test-coverage --test-coverage-lines=97 --test-coverage-branches=93 --test-coverage-functions=93 --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info test/*.js"
+    "test": "node --expose-gc --test test/*.js",
+    "coverage": "mkdir -p coverage && node --expose-gc --test --experimental-test-coverage --test-coverage-lines=97 --test-coverage-branches=93 --test-coverage-functions=93 --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info test/*.js"
   },
   "dependencies": {
     "mongodb": "^7.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,257 +13,257 @@ importers:
         version: 7.2.0
     devDependencies:
       oxfmt:
-        specifier: ^0.47.0
-        version: 0.47.0
+        specifier: ^0.54.0
+        version: 0.54.0
       oxlint:
-        specifier: ^1.62.0
-        version: 1.62.0
+        specifier: ^1.69.0
+        version: 1.69.0
 
 packages:
 
-  '@mongodb-js/saslprep@1.4.9':
-    resolution: {integrity: sha512-RXSxsokhAF/4nWys8An8npsqOI33Ex1Hlzqjw2pZOO+GKtMAR2noGnUdsFiGwsaO/xXI+56mtjTmDA3JXJsvmA==}
+  '@mongodb-js/saslprep@1.4.11':
+    resolution: {integrity: sha512-o9rAHc0IpIjuPSxRutWpE1F62x7n+4mVS4rCNHkzhIUMQcc18bb6xEq5wd2NdN0WjepIyXIppRshYI2kQDOZVA==}
 
-  '@oxfmt/binding-android-arm-eabi@0.47.0':
-    resolution: {integrity: sha512-KrMQRdMi/upr81qT4ijK6X6BNp6jqpMY7FwILQnwIy9QLc3qpnhUx5rsCLGzn4ewsCQ0CNAspN2ogmP1GXLyLw==}
+  '@oxfmt/binding-android-arm-eabi@0.54.0':
+    resolution: {integrity: sha512-NAtpl/SiaeU103e7/OmZw0MvUnsUUopW7hEm/ecegJg7YM0skQaA0IXEZoyTV6NUdiNPupdIUreRqUZTShbn/g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxfmt/binding-android-arm64@0.47.0':
-    resolution: {integrity: sha512-r4ixS/PeUpAFKgrpDoZ5pSkthjZzVzKd95525Aazj+aOv9H4ulK5zYHGb7wFY5n5kZxHK8TbOJUZgoEb1ohddQ==}
+  '@oxfmt/binding-android-arm64@0.54.0':
+    resolution: {integrity: sha512-B4VZfBUlKK1rmMChsssNZbkZjE8+FzG3avMjGgMDwbGxXRoXkoeXiAZ+78Oa+eyDPHvDCiUb4zH/vmCOUSafLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxfmt/binding-darwin-arm64@0.47.0':
-    resolution: {integrity: sha512-CLWxiKpMl+195cm09CuaWEhJK0CirRkoMa07aR9+9AFPat2LfIKtwx1JqxZM0MTvcMe6+adlJNdVL6jdInvq3g==}
+  '@oxfmt/binding-darwin-arm64@0.54.0':
+    resolution: {integrity: sha512-i02vF75b+ePsQP3tHqSxVYI5S6b8X/xqdPu7/mDHXtpgXLTYXi3jJmfHU0j+dnZZDKaYTx/ioCK7QYJmtiJR2g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxfmt/binding-darwin-x64@0.47.0':
-    resolution: {integrity: sha512-Xq5fjTYDC50faUeLSm0rZdBqoTgleXEdD7NpJdARtQIczkCJn3xNjMUSQQkUmh4CtxkKTNL68lytcOK3e/osgg==}
+  '@oxfmt/binding-darwin-x64@0.54.0':
+    resolution: {integrity: sha512-8VMFvGvooXj7mswkbrhdVZ2/sgiDaBzWpkkbtO+qGDLV4EfJd67nQadHkQC0ZNbaWA9ajXfqI6i7PZLIeDzxEQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxfmt/binding-freebsd-x64@0.47.0':
-    resolution: {integrity: sha512-QOU9ZIJ52p5askcEC0QJvvr8trHAWoonul8bgISo6gYUL3s50zkqafBYcNAr9LJZQbsZtPfIWHk9+5+nUp1qJQ==}
+  '@oxfmt/binding-freebsd-x64@0.54.0':
+    resolution: {integrity: sha512-0cRHnp43WN1Jrc5s0BdbdKgR1XirdvHy7TAFi3JEsoEVQVJxTXMbpVd76sxXlgRswNMDhVFSJw+y7Eb8mEavFQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.47.0':
-    resolution: {integrity: sha512-oJxDM1aBhPvz9gmElBv8UpxyiqhwfjcbrSxT5F0xtuUzY6dQI27/AQPIt3eu3Z5Yvn0kQl5R7MA3Z+MbnRvCBw==}
+  '@oxfmt/binding-linux-arm-gnueabihf@0.54.0':
+    resolution: {integrity: sha512-JyQAk3hK/OEtup7Rw6kZwfdzbKqTVD5jXXb8Xpfay29suwZyfBDMVW/bj4RqEPySYWc6zCp198pOluf8n5uYzg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.47.0':
-    resolution: {integrity: sha512-g8Lh50VS4ibGz2q6v7r9UZY4D0dM16SdrFYOMzhqIoCwGcai8VMIRUAcqn1/jlCsOOzUXJ741+kCeJt0cofakQ==}
+  '@oxfmt/binding-linux-arm-musleabihf@0.54.0':
+    resolution: {integrity: sha512-qnvLatTpM8vtvjOfcckBOzJjk+n6ce/wwpP8OFeUrD5aNLYcKyWAitwj+Rk3PK9jGanbZvKsJnv14JGQ6XqFdw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm64-gnu@0.47.0':
-    resolution: {integrity: sha512-YrNT1vQ0asaXoRbrvYENPqmBfOQ9Xr8enPNOULeYfg44VjCcrUowFy5QZr+WawE0zyP8cH9e9Gxxg0fDEFzhcg==}
+  '@oxfmt/binding-linux-arm64-gnu@0.54.0':
+    resolution: {integrity: sha512-SMkhnCzIYZYDk9vw3W/80eeYKmrMpGF0Giuxt4HruFlCH7jEtnPeb3SdQKMfgYi/dgtaf+hZAb5XWPYnxqCQ3w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-arm64-musl@0.47.0':
-    resolution: {integrity: sha512-IxtQC/sbBi4ubbY+MdwdanRWrG9InQJVZqyMsBa5IUaQcnSg86gQme574HxXMC1p4bo4YhV99zQ+wNnGCvEgzw==}
+  '@oxfmt/binding-linux-arm64-musl@0.54.0':
+    resolution: {integrity: sha512-QrwJlBFFKnxOd95TAaszpMbZBLzMoYMpGaQTZF8oibacnF5rv8l12IhILhQRPmksWiBqg0YSe2Mnl7ayeJAHSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.47.0':
-    resolution: {integrity: sha512-EWXEhOMbWO0q6eJSbu0QLkU8cKi0ljlYLngeDs2Ocu/pm1rrLwyQiYzlFbdnMRURI4w9ndr1sI9rSbhlJ5o23Q==}
+  '@oxfmt/binding-linux-ppc64-gnu@0.54.0':
+    resolution: {integrity: sha512-WILatiol/TUHTlhod7R09+7Az/XlhKwmY1MHfLZNmewltPWNN/EwxP2rQSHahibZ/cB8gmckEBjBOByD+5bYsQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.47.0':
-    resolution: {integrity: sha512-tZrjS11TUiDuEpRaqdk8K9F9xETRyKXfuZKmdeW+Gj7coBnm7+8sBEfyt033EAFEQSlkniAXvBLh+Qja2ioGBQ==}
+  '@oxfmt/binding-linux-riscv64-gnu@0.54.0':
+    resolution: {integrity: sha512-f05YMG4BH4G8S4ME6UM6fi1MnJ9094mrnvO5Pa4SJlMfWlUM+1/ZWMEF4NnjM7shZAvbHsHRuVYpUo0PHC4P9Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-riscv64-musl@0.47.0':
-    resolution: {integrity: sha512-KBFy+2CFKUCZzYwX2ZOPQKck1vjQbz+hextuc19G4r0WRJwadfAeuQMQRQvB+Ivc8brlbOVg7et8K7E467440g==}
+  '@oxfmt/binding-linux-riscv64-musl@0.54.0':
+    resolution: {integrity: sha512-UfL+2hj1ClNqcCRT9s8vBU4axDpjxgVxX96G+9DYAYjoc5b0u15CJtn2jgsi9iM+EbGNc5CW1HVRgwVu76UsSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-linux-s390x-gnu@0.47.0':
-    resolution: {integrity: sha512-REUPFKVGSiK99B+9eaPhluEVglzaoj/SMykNC5SUiV2RSsBfV5lWN7Y0iCIc251Wz3GaeAGZsJ/zj3gjarxdFg==}
+  '@oxfmt/binding-linux-s390x-gnu@0.54.0':
+    resolution: {integrity: sha512-3/XZe931Hka+J6NjnaqJzYpsWWxDTuRdUdwSQHnOuJEgbC+SehIMFJS8hsEjV7LBhVSL2OCnRLvbVW8O97XIyw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-x64-gnu@0.47.0':
-    resolution: {integrity: sha512-KVftVSVEDeIfRW3TIeLe3aNI/iY4m1fu5mDwHcisKMZSCMKLkrhFsjowC7o9RoqNPxbbglm2+/6KAKBIts2t0Q==}
+  '@oxfmt/binding-linux-x64-gnu@0.54.0':
+    resolution: {integrity: sha512-Ik93RlObtu43GbxApafayFjwYE06L6Xr08cSwpBPYbDrLp2ReZx0Jm1DqwRyYRnukUJy+rK2WaEvUQOxdytU9Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-x64-musl@0.47.0':
-    resolution: {integrity: sha512-DTsmGEaA2860Aq5VUyDO8/MT9NFxwVL93RnRYmpMwK6DsSkThmvEpqoUDDljziEpAedMRG19SCogrNbINSbLUQ==}
+  '@oxfmt/binding-linux-x64-musl@0.54.0':
+    resolution: {integrity: sha512-yZcakmPlD86CNymknd7KfW+FH+qfbqJH+i0h69CYfV1+KMoVeM9UED+8+TDVoU4haxI0NxY7RPCvRLy3Sqd2Qg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-openharmony-arm64@0.47.0':
-    resolution: {integrity: sha512-8r5BDro7fLOBoq1JXHLVSs55OlrxQhEso4HVo0TcY7OXJUPYfjPoOaYL5us+yIwqyP9rQwN+rxuiNFSmaxSuOQ==}
+  '@oxfmt/binding-openharmony-arm64@0.54.0':
+    resolution: {integrity: sha512-GiVBZNnEZnKu00f1jTg49nomv187d0GQX+O+ocykoLeiaALuEO+swoTehHn9TehTfi7V8H0i0e/yvUjCqnwk1w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxfmt/binding-win32-arm64-msvc@0.47.0':
-    resolution: {integrity: sha512-qtz/gzm8IjSPUlseZ0ofW8zyHLoZsuP5HTfcGGkWkUblB89JT8GNYH3ICqjbDsqsGqXum0/ZndXTFplSdXFIcg==}
+  '@oxfmt/binding-win32-arm64-msvc@0.54.0':
+    resolution: {integrity: sha512-J0SSB8Z1Fre2sxRolYcW6Rl1RQmKdQ2hnHyq4YJrfBRiXTObLw4DXnIVraM/UyqGqwOi7yTrQA4VT7DPxlHVKA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxfmt/binding-win32-ia32-msvc@0.47.0':
-    resolution: {integrity: sha512-5vIcdcIDE7nCx+MXN6sm8kbC4zajDB31E86rez4i45iHNH/2NjdKlJ720xcHTr3eeiMcttCGPHPhE1TjtBDGZw==}
+  '@oxfmt/binding-win32-ia32-msvc@0.54.0':
+    resolution: {integrity: sha512-O61UDVj8zz6yXJjkHPf05VaMLOXmEF8P5kf/N0W7AQMmd6bcQogl+KJc7rMutKTL524oE9iH32JXZClBFmEQIg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxfmt/binding-win32-x64-msvc@0.47.0':
-    resolution: {integrity: sha512-Sr59Y5ms54ONBjxFeWhVlGyQcHXxcl9DxC23f6yXlRkcos7LXBLoO+KDfxexjHIOZh7cWqrWduzvUjJ+pHp8cQ==}
+  '@oxfmt/binding-win32-x64-msvc@0.54.0':
+    resolution: {integrity: sha512-1MDpqJPiFqxWtIHas8vkb1VZ7f7eKyTffAwmO8isxQYMaG1OFKsH666BWLeXQLO+IWNfiMssLD55hbR1lIPTqg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@oxlint/binding-android-arm-eabi@1.62.0':
-    resolution: {integrity: sha512-pKsthNECyvJh8lPTICz6VcwVy2jOqdhhsp1rlxCkhgZR47aKvXPmaRWQDv+zlXpRae4qm1MaaTnutkaOk5aofg==}
+  '@oxlint/binding-android-arm-eabi@1.69.0':
+    resolution: {integrity: sha512-DKQQbD5cZ/MYfDgDI7YGyGD9FSxABlsBsYFo5p26lloob543tP9+4N3guwdXIYJN+7HSZxLe8YJuwcOWw5qnHg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxlint/binding-android-arm64@1.62.0':
-    resolution: {integrity: sha512-b1AUNViByvgmR2xJDubvLIr+dSuu3uraG7bsAoKo+xrpspPvu6RIn6Fhr2JUhobfep3jwUTy18Huco6GkwdvGQ==}
+  '@oxlint/binding-android-arm64@1.69.0':
+    resolution: {integrity: sha512-lEhb+I5pr4inux+JFwfCa1HRq3Os7NirEFQ0H1I35SVEHPm6byX0Ah47xmRha3qi6LAkxUcxViL8o/9PivjzBg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxlint/binding-darwin-arm64@1.62.0':
-    resolution: {integrity: sha512-iG+Tvf70UJ6otfwFYIHk36Sjq9cpPP5YLxkoggANNRtzgi3Tj3g8q6Ybqi6AtkU3+yg9QwF7bDCkCS6bbL4PCg==}
+  '@oxlint/binding-darwin-arm64@1.69.0':
+    resolution: {integrity: sha512-GY2YE8lOZW59BW1Ia1y+1gR0XyjrZRvVWHAr8LGeGhYHE0OQJ/7cRKXTkx1P+E9/6awEc3SX8a68SFTjh/E//A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint/binding-darwin-x64@1.62.0':
-    resolution: {integrity: sha512-oOWI6YPPr5AJUx+yIDlxmuUbQjS5gZX3OH3QisawYvsZgLiQVvZtR0rPBcJTxLWqt2ClrWg0DlSrlUiG5SQNHg==}
+  '@oxlint/binding-darwin-x64@1.69.0':
+    resolution: {integrity: sha512-ax1oZnOjHX3LB7myQyHEaQkDwfLb6str3/nSP6O7EVUviQGNkEGzGV0EqcBJWK+Ufwx0l4xPgyYayurvhAdl2Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint/binding-freebsd-x64@1.62.0':
-    resolution: {integrity: sha512-dLP33T7VLCmLVv4cvjkVX+rmkcwNk2UfxmsZPNur/7BQHoQR60zJ7XLiRvNUawlzn0u8ngCa3itjEG73MAMa/w==}
+  '@oxlint/binding-freebsd-x64@1.69.0':
+    resolution: {integrity: sha512-kHWeHv4g2h8NY+mpCxzCtY4uerMJWTN/TSnNj1CPbakFpHEJ6cTya2wWV0pDSYWOJ2+0UiEbhn3AtXxHtsnKjg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.62.0':
-    resolution: {integrity: sha512-fl//LWNks6qo9chNY60UDYyIwtp7a5cEx4Y/rHPjaarhuwqx6jtbzEpD5V5AqmdL4a6Y5D8zeXg5HF2Cr0QmSQ==}
+  '@oxlint/binding-linux-arm-gnueabihf@1.69.0':
+    resolution: {integrity: sha512-gq84vM1a1oEehXo27YCDzGVcxPsZDI1yswZwz2Da1/cbnWtrL16XZZnz0G/+gIU8edtHpfjxq5c+vWEHqJfWoQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm-musleabihf@1.62.0':
-    resolution: {integrity: sha512-i5vkAuxvueTODV3J2dL61/TXewDHhMFKvtD156cIsk7GsdfiAu7zW7kY0NJXhKeFHeiMZIh7eFNjkPYH6J47HQ==}
+  '@oxlint/binding-linux-arm-musleabihf@1.69.0':
+    resolution: {integrity: sha512-kIqEa98JQ0VRyrcncxA417m2AzasqTlD+FyVT1AksjvjkqQcvm7pBWYvoW3/mpyOP2XYvi5nSCCTIe6De1yu5g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm64-gnu@1.62.0':
-    resolution: {integrity: sha512-QwN19LLuIGuOjEflSeJkZmOTfBdBMlTmW8xbMf8TZhjd//cxVNYQPq75q7oKZBJc6hRx3gY7sX0Egc8cEIFZYg==}
+  '@oxlint/binding-linux-arm64-gnu@1.69.0':
+    resolution: {integrity: sha512-j+xYiXozxGWx2cpjCrwwGR4awTxPFsRv3JZrv23RCogEPMc4R7UqjHW47p/RG0aRlbWiROCJ8coUfCwy0dvzHA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-arm64-musl@1.62.0':
-    resolution: {integrity: sha512-8eCy3FCDuWUM5hWujAv6heMvfZPbcCOU3SdQUAkixZLu5bSzOkNfirJiLGoQFO943xceOKkiQRMQNzH++jM3WA==}
+  '@oxlint/binding-linux-arm64-musl@1.69.0':
+    resolution: {integrity: sha512-xEPpNppTfN1l/nM7gYSf9iocscu/as+p/7vxkLeLEKnYU+09Dm+5V6IhDYDh+Uz6FajEupWwCLt5SOG0y1PCKg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-ppc64-gnu@1.62.0':
-    resolution: {integrity: sha512-NjQ7K7tpTPDe9J+yq8p/s/J0E7lRCkK2uDBDqvT4XIT6f4Z0tlnr59OBg/WcrmVHER1AbrcfyxhGTXgcG8ytWg==}
+  '@oxlint/binding-linux-ppc64-gnu@1.69.0':
+    resolution: {integrity: sha512-Ug0+eU7HJBlek+SjklYH62IlOMirEJsdxpihH0kSqX0XdrDD4NdHpQc10fK1JC35yn6KrrcN+uYzlHD38XAf8Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-gnu@1.62.0':
-    resolution: {integrity: sha512-oKZed9gmSwze29dEt3/Wnsv6l/Ygw/FUst+8Kfpv2SGeS/glEoTGZAMQw37SVyzFV76UTHJN2snGgxK2t2+8ow==}
+  '@oxlint/binding-linux-riscv64-gnu@1.69.0':
+    resolution: {integrity: sha512-iEyI3GIg0l/s3G4qy2TlaaWKdzj4PJJStwtlocpDTC00PY9hZueotf6OKUj9+yfQh0lrpBW/pLMgTztbAHKJEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-musl@1.62.0':
-    resolution: {integrity: sha512-gBjBxQ+9lGpAYq+ELqw0w8QXsBnkZclFc7GRX2r0LnEVn3ZTEqeIKpKcGjucmp76Q53bvJD0i4qBWBhcfhSfGA==}
+  '@oxlint/binding-linux-riscv64-musl@1.69.0':
+    resolution: {integrity: sha512-NjHjpiI4WIKSMwuoJSZi5VToPeoYOS1FR52HLIDG6lidMdqquusgtODb4iLk0+lb1q3Z0nv2/aPRcC/olmpQGg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-s390x-gnu@1.62.0':
-    resolution: {integrity: sha512-Ew2Kxs9EQ9/mbAIJ2hvocMC0wsOu6YKzStI2eFBDt+Td5O8seVC/oxgRIHqCcl5sf5ratA1nozQBAuv7tphkHg==}
+  '@oxlint/binding-linux-s390x-gnu@1.69.0':
+    resolution: {integrity: sha512-Ai/prDewoItkDXbp38gwGZi41DycZbUTZJ3UidwoHgQC0/DaqC2TGdtBTQLJ6hSD+SAxASzh8+/eSBPmxfOacA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-gnu@1.62.0':
-    resolution: {integrity: sha512-5z25jcAA0gfKyVwz71A0VXgaPlocPoTAxhlv/hgoK6tlCrfoNuw7haWbDHvGMfjXhdic4EqVXGRv5XsTqFnbRQ==}
+  '@oxlint/binding-linux-x64-gnu@1.69.0':
+    resolution: {integrity: sha512-Gt3KHgp46mRKz4sJeaASmKvD8ayXookRw07RMf+NowhEztGGDZ7VrXpoW96XuKJLjFukWizOFVNjmYb/u7caNQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-musl@1.62.0':
-    resolution: {integrity: sha512-IWpHmMB6ZDllPvqWDkG6AmXrN7JF5e/c4g/0PuURsmlK+vHoYZPB70rr4u1bn3I4LsKCSpqqfveyx6UCOC8wdg==}
+  '@oxlint/binding-linux-x64-musl@1.69.0':
+    resolution: {integrity: sha512-7tQhJ2+p/oHv1zcfnjYI7YVzC/7iBaVOfIvFYtxdJ5F45mWgEdrCyXZXZGfiLey5t/5JhOhsaMnnv1kAzckd7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-openharmony-arm64@1.62.0':
-    resolution: {integrity: sha512-fjlSxxrD5pA594vkyikCS9MnPRjQawW6/BLgyTYkO+73wwPlYjkcZ7LSd974l0Q2zkHQmu4DPvJFLYA7o8xrxQ==}
+  '@oxlint/binding-openharmony-arm64@1.69.0':
+    resolution: {integrity: sha512-vmWz6TKp/3hfA4lksR0zHBv/6xuX1jhym6eqOjdH2DXsDDHZWcp2f0KG0VCAnlVbIrjk29G4wAWMXb/Hn1YobA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxlint/binding-win32-arm64-msvc@1.62.0':
-    resolution: {integrity: sha512-EiFXr8loNS0Ul3Gu80+9nr1T8jRmnKocqmHHg16tj5ZqTgUXyb97l2rrspVHdDluyFn9JfR4PoJFdNzw4paHww==}
+  '@oxlint/binding-win32-arm64-msvc@1.69.0':
+    resolution: {integrity: sha512-9RExaLgmaw6IoIkU9cTpT71mLfI0xZ86iZH8x518LVsOkjquJMYqb9P7KpC8lgd1t0Dxs41p2pxynq4XR3Ttzw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint/binding-win32-ia32-msvc@1.62.0':
-    resolution: {integrity: sha512-IgOFvL73li1bFgab+hThXYA0N2Xms2kV2MvZN95cebV+fmrZ9AVui1JSxfeeqRLo3CpPxKZlzhyq4G0cnaAvIw==}
+  '@oxlint/binding-win32-ia32-msvc@1.69.0':
+    resolution: {integrity: sha512-1907kRPF8/PrcIw1E7LMs9JbVrpgnt/MvFdss3an8oDkYNAACXzTntV3t3869ZZhMZxb2AzRGbz1pA/jdFatXA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxlint/binding-win32-x64-msvc@1.62.0':
-    resolution: {integrity: sha512-6hMpyDWQ2zGA1OXFKBrdYMUveUCO8UJhkO6JdwZPd78xIdHZNhjx+pib+4fC2Cljuhjyl0QwA2F3df/bs4Bp6A==}
+  '@oxlint/binding-win32-x64-msvc@1.69.0':
+    resolution: {integrity: sha512-w8SOXv3mT9Fi6jY8OXdXCfnvX/3KNLXGNr4HEz2TA7S4Mv/PYAOmpB8y/ge40mxvBMgGNaSaaDwZpAsQn7HtWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -312,19 +312,30 @@ packages:
       socks:
         optional: true
 
-  oxfmt@0.47.0:
-    resolution: {integrity: sha512-OFbkbzxKCpooQEnRmpTDnuwTX8KHXzZTQ4Df/hz85fpS67Pl+lxPEFvUtin56HIIS0B1k4X8oIzTXRZPufA2CA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-
-  oxlint@1.62.0:
-    resolution: {integrity: sha512-1uFkg6HakjsGIpW9wNdeW4/2LOHW9MEkoWjZUTUfQtIHyLIZPYt00w3Sg+H3lH+206FgBPHBbW5dVE5l2ExECQ==}
+  oxfmt@0.54.0:
+    resolution: {integrity: sha512-DjnMwn7smSLF+Mc2+pRItnuPftm/dkUFpY/d4+33y9TfKrsHZo8GLhmUg9BrOIUEy94Rlom1Q11N6vuhE+e0oQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      oxlint-tsgolint: '>=0.18.0'
+      svelte: ^5.0.0
+      vite-plus: '*'
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+      vite-plus:
+        optional: true
+
+  oxlint@1.69.0:
+    resolution: {integrity: sha512-ypZkK/aDc5NQV8zIR6s2H2Tl3aNW8FmJ1m9+2qsaYuRenl8vgnHNCGwTHviWJdUQzglOlHFchgopdtGhSy17Rw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.22.1'
+      vite-plus: '*'
     peerDependenciesMeta:
       oxlint-tsgolint:
+        optional: true
+      vite-plus:
         optional: true
 
   punycode@2.3.1:
@@ -352,122 +363,122 @@ packages:
 
 snapshots:
 
-  '@mongodb-js/saslprep@1.4.9':
+  '@mongodb-js/saslprep@1.4.11':
     dependencies:
       sparse-bitfield: 3.0.3
 
-  '@oxfmt/binding-android-arm-eabi@0.47.0':
+  '@oxfmt/binding-android-arm-eabi@0.54.0':
     optional: true
 
-  '@oxfmt/binding-android-arm64@0.47.0':
+  '@oxfmt/binding-android-arm64@0.54.0':
     optional: true
 
-  '@oxfmt/binding-darwin-arm64@0.47.0':
+  '@oxfmt/binding-darwin-arm64@0.54.0':
     optional: true
 
-  '@oxfmt/binding-darwin-x64@0.47.0':
+  '@oxfmt/binding-darwin-x64@0.54.0':
     optional: true
 
-  '@oxfmt/binding-freebsd-x64@0.47.0':
+  '@oxfmt/binding-freebsd-x64@0.54.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.47.0':
+  '@oxfmt/binding-linux-arm-gnueabihf@0.54.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.47.0':
+  '@oxfmt/binding-linux-arm-musleabihf@0.54.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-gnu@0.47.0':
+  '@oxfmt/binding-linux-arm64-gnu@0.54.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-musl@0.47.0':
+  '@oxfmt/binding-linux-arm64-musl@0.54.0':
     optional: true
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.47.0':
+  '@oxfmt/binding-linux-ppc64-gnu@0.54.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.47.0':
+  '@oxfmt/binding-linux-riscv64-gnu@0.54.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-musl@0.47.0':
+  '@oxfmt/binding-linux-riscv64-musl@0.54.0':
     optional: true
 
-  '@oxfmt/binding-linux-s390x-gnu@0.47.0':
+  '@oxfmt/binding-linux-s390x-gnu@0.54.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-gnu@0.47.0':
+  '@oxfmt/binding-linux-x64-gnu@0.54.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-musl@0.47.0':
+  '@oxfmt/binding-linux-x64-musl@0.54.0':
     optional: true
 
-  '@oxfmt/binding-openharmony-arm64@0.47.0':
+  '@oxfmt/binding-openharmony-arm64@0.54.0':
     optional: true
 
-  '@oxfmt/binding-win32-arm64-msvc@0.47.0':
+  '@oxfmt/binding-win32-arm64-msvc@0.54.0':
     optional: true
 
-  '@oxfmt/binding-win32-ia32-msvc@0.47.0':
+  '@oxfmt/binding-win32-ia32-msvc@0.54.0':
     optional: true
 
-  '@oxfmt/binding-win32-x64-msvc@0.47.0':
+  '@oxfmt/binding-win32-x64-msvc@0.54.0':
     optional: true
 
-  '@oxlint/binding-android-arm-eabi@1.62.0':
+  '@oxlint/binding-android-arm-eabi@1.69.0':
     optional: true
 
-  '@oxlint/binding-android-arm64@1.62.0':
+  '@oxlint/binding-android-arm64@1.69.0':
     optional: true
 
-  '@oxlint/binding-darwin-arm64@1.62.0':
+  '@oxlint/binding-darwin-arm64@1.69.0':
     optional: true
 
-  '@oxlint/binding-darwin-x64@1.62.0':
+  '@oxlint/binding-darwin-x64@1.69.0':
     optional: true
 
-  '@oxlint/binding-freebsd-x64@1.62.0':
+  '@oxlint/binding-freebsd-x64@1.69.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.62.0':
+  '@oxlint/binding-linux-arm-gnueabihf@1.69.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-musleabihf@1.62.0':
+  '@oxlint/binding-linux-arm-musleabihf@1.69.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-gnu@1.62.0':
+  '@oxlint/binding-linux-arm64-gnu@1.69.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-musl@1.62.0':
+  '@oxlint/binding-linux-arm64-musl@1.69.0':
     optional: true
 
-  '@oxlint/binding-linux-ppc64-gnu@1.62.0':
+  '@oxlint/binding-linux-ppc64-gnu@1.69.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-gnu@1.62.0':
+  '@oxlint/binding-linux-riscv64-gnu@1.69.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-musl@1.62.0':
+  '@oxlint/binding-linux-riscv64-musl@1.69.0':
     optional: true
 
-  '@oxlint/binding-linux-s390x-gnu@1.62.0':
+  '@oxlint/binding-linux-s390x-gnu@1.69.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-gnu@1.62.0':
+  '@oxlint/binding-linux-x64-gnu@1.69.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-musl@1.62.0':
+  '@oxlint/binding-linux-x64-musl@1.69.0':
     optional: true
 
-  '@oxlint/binding-openharmony-arm64@1.62.0':
+  '@oxlint/binding-openharmony-arm64@1.69.0':
     optional: true
 
-  '@oxlint/binding-win32-arm64-msvc@1.62.0':
+  '@oxlint/binding-win32-arm64-msvc@1.69.0':
     optional: true
 
-  '@oxlint/binding-win32-ia32-msvc@1.62.0':
+  '@oxlint/binding-win32-ia32-msvc@1.69.0':
     optional: true
 
-  '@oxlint/binding-win32-x64-msvc@1.62.0':
+  '@oxlint/binding-win32-x64-msvc@1.69.0':
     optional: true
 
   '@types/webidl-conversions@7.0.3': {}
@@ -487,55 +498,55 @@ snapshots:
 
   mongodb@7.2.0:
     dependencies:
-      '@mongodb-js/saslprep': 1.4.9
+      '@mongodb-js/saslprep': 1.4.11
       bson: 7.2.0
       mongodb-connection-string-url: 7.0.1
 
-  oxfmt@0.47.0:
+  oxfmt@0.54.0:
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
-      '@oxfmt/binding-android-arm-eabi': 0.47.0
-      '@oxfmt/binding-android-arm64': 0.47.0
-      '@oxfmt/binding-darwin-arm64': 0.47.0
-      '@oxfmt/binding-darwin-x64': 0.47.0
-      '@oxfmt/binding-freebsd-x64': 0.47.0
-      '@oxfmt/binding-linux-arm-gnueabihf': 0.47.0
-      '@oxfmt/binding-linux-arm-musleabihf': 0.47.0
-      '@oxfmt/binding-linux-arm64-gnu': 0.47.0
-      '@oxfmt/binding-linux-arm64-musl': 0.47.0
-      '@oxfmt/binding-linux-ppc64-gnu': 0.47.0
-      '@oxfmt/binding-linux-riscv64-gnu': 0.47.0
-      '@oxfmt/binding-linux-riscv64-musl': 0.47.0
-      '@oxfmt/binding-linux-s390x-gnu': 0.47.0
-      '@oxfmt/binding-linux-x64-gnu': 0.47.0
-      '@oxfmt/binding-linux-x64-musl': 0.47.0
-      '@oxfmt/binding-openharmony-arm64': 0.47.0
-      '@oxfmt/binding-win32-arm64-msvc': 0.47.0
-      '@oxfmt/binding-win32-ia32-msvc': 0.47.0
-      '@oxfmt/binding-win32-x64-msvc': 0.47.0
+      '@oxfmt/binding-android-arm-eabi': 0.54.0
+      '@oxfmt/binding-android-arm64': 0.54.0
+      '@oxfmt/binding-darwin-arm64': 0.54.0
+      '@oxfmt/binding-darwin-x64': 0.54.0
+      '@oxfmt/binding-freebsd-x64': 0.54.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.54.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.54.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.54.0
+      '@oxfmt/binding-linux-arm64-musl': 0.54.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.54.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.54.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.54.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.54.0
+      '@oxfmt/binding-linux-x64-gnu': 0.54.0
+      '@oxfmt/binding-linux-x64-musl': 0.54.0
+      '@oxfmt/binding-openharmony-arm64': 0.54.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.54.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.54.0
+      '@oxfmt/binding-win32-x64-msvc': 0.54.0
 
-  oxlint@1.62.0:
+  oxlint@1.69.0:
     optionalDependencies:
-      '@oxlint/binding-android-arm-eabi': 1.62.0
-      '@oxlint/binding-android-arm64': 1.62.0
-      '@oxlint/binding-darwin-arm64': 1.62.0
-      '@oxlint/binding-darwin-x64': 1.62.0
-      '@oxlint/binding-freebsd-x64': 1.62.0
-      '@oxlint/binding-linux-arm-gnueabihf': 1.62.0
-      '@oxlint/binding-linux-arm-musleabihf': 1.62.0
-      '@oxlint/binding-linux-arm64-gnu': 1.62.0
-      '@oxlint/binding-linux-arm64-musl': 1.62.0
-      '@oxlint/binding-linux-ppc64-gnu': 1.62.0
-      '@oxlint/binding-linux-riscv64-gnu': 1.62.0
-      '@oxlint/binding-linux-riscv64-musl': 1.62.0
-      '@oxlint/binding-linux-s390x-gnu': 1.62.0
-      '@oxlint/binding-linux-x64-gnu': 1.62.0
-      '@oxlint/binding-linux-x64-musl': 1.62.0
-      '@oxlint/binding-openharmony-arm64': 1.62.0
-      '@oxlint/binding-win32-arm64-msvc': 1.62.0
-      '@oxlint/binding-win32-ia32-msvc': 1.62.0
-      '@oxlint/binding-win32-x64-msvc': 1.62.0
+      '@oxlint/binding-android-arm-eabi': 1.69.0
+      '@oxlint/binding-android-arm64': 1.69.0
+      '@oxlint/binding-darwin-arm64': 1.69.0
+      '@oxlint/binding-darwin-x64': 1.69.0
+      '@oxlint/binding-freebsd-x64': 1.69.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.69.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.69.0
+      '@oxlint/binding-linux-arm64-gnu': 1.69.0
+      '@oxlint/binding-linux-arm64-musl': 1.69.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.69.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.69.0
+      '@oxlint/binding-linux-riscv64-musl': 1.69.0
+      '@oxlint/binding-linux-s390x-gnu': 1.69.0
+      '@oxlint/binding-linux-x64-gnu': 1.69.0
+      '@oxlint/binding-linux-x64-musl': 1.69.0
+      '@oxlint/binding-openharmony-arm64': 1.69.0
+      '@oxlint/binding-win32-arm64-msvc': 1.69.0
+      '@oxlint/binding-win32-ia32-msvc': 1.69.0
+      '@oxlint/binding-win32-x64-msvc': 1.69.0
 
   punycode@2.3.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       mongodb:
-        specifier: ^7.2
-        version: 7.2.0
+        specifier: ^7.3.0
+        version: 7.3.0
     devDependencies:
       oxfmt:
         specifier: ^0.54.0
@@ -285,8 +285,8 @@ packages:
     resolution: {integrity: sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==}
     engines: {node: '>=20.19.0'}
 
-  mongodb@7.2.0:
-    resolution: {integrity: sha512-F/2+BMZtLVhY30ioZp0dAmZ+IRZMBqI+nrv6t5+9/1AIwCa8sMRC3jBf81lpxMhnZgqq8CoUD503Z1oZWq1/sw==}
+  mongodb@7.3.0:
+    resolution: {integrity: sha512-WpCqSx7JAU9vcyjm/SU7ydnHls2YrfU3Y3sx4Ml9D7sPe4mXPlaapndiurDXrQ7/VvJkB4/i7b7WovHb8bd8sg==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@aws-sdk/credential-providers': ^3.806.0
@@ -496,7 +496,7 @@ snapshots:
       '@types/whatwg-url': 13.0.0
       whatwg-url: 14.2.0
 
-  mongodb@7.2.0:
+  mongodb@7.3.0:
     dependencies:
       '@mongodb-js/saslprep': 1.4.11
       bson: 7.2.0

--- a/readme.md
+++ b/readme.md
@@ -9,8 +9,8 @@ A thin, opinionated wrapper around the official MongoDB Node.js driver. Every pu
 
 ## Requirements
 
-- Node.js ≥ 24.14
-- MongoDB server 7.0, 8.0, or 8.2
+- Node.js ≥ 24.16
+- MongoDB server 7.0, 8.0, 8.2, or 8.3
 
 ## Installation
 

--- a/readme.md
+++ b/readme.md
@@ -243,7 +243,7 @@ if (failure) {
 }
 ```
 
-`findById` has no options slot — use `findOne({ _id: id }, { onError })`. For `ensureIndexes`, pass `onError` inside each spec's `options`. A throwing local handler is caught and ignored, same as the client-level one.
+`findById` has no options slot — use `findOne({ _id: id }, { onError })`. For `ensureIndexes`, pass `onError` inside each spec's `options`. A throwing local handler is caught and ignored, same as the client-level one. One caveat for `each()`: the local handler should not capture its own iterator, or an abandoned iterator can never be garbage-collected and its cursor stays pinned until the client is closed.
 
 ## Empty filter protection
 

--- a/readme.md
+++ b/readme.md
@@ -123,7 +123,9 @@ await users.find({}, { fields: { password: 0 } }); // exclusion map, passed thro
 await users.find({}, { projection: { name: 1 } }); // native driver shape, passed through as-is
 ```
 
-`findById` accepts the same forms positionally: `findById(id, ['name'])`.
+The array form fails closed: it always produces a projection. Non-string entries are ignored, and when nothing usable remains (`[]`, `['__proto__']`, `[42]`) the projection collapses to `{ _id: 1 }` — a user-controlled array cannot silently disable a field whitelist.
+
+`findById` accepts the array and map forms positionally: `findById(id, ['name'])`.
 
 ## Streaming reads
 

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 [![Coverage status][coveralls-image]][coveralls-url]
 [![Dependency status][libraries-image]][libraries-url]
 
-A thin, opinionated wrapper around the official MongoDB Node.js driver. Every public method returns a promise with a fixed resolved type; driver errors are swallowed and replaced with the empty default (`null`, `false`, `[]`, or `0`).
+A thin, opinionated wrapper around the official MongoDB Node.js driver. Every async method resolves to a fixed type; driver errors are swallowed and replaced with the empty default (`null`, `false`, `[]`, or `0`).
 
 ## Requirements
 
@@ -101,7 +101,7 @@ Every async method except `findById` accepts `options.signal: AbortSignal` and `
 
 ## Read options
 
-The second argument to `find`, `findOne`, and `findById`:
+The second argument to `find` and `findOne`:
 
 ```js
 await users.find(
@@ -146,7 +146,9 @@ For long-running iteration, scope the cursor with `await using` so it is closed 
 {
   await using cursor = users.each({ active: true });
   for await (const user of cursor) {
-    if (!shouldShip(user)) break;
+    if (!shouldShip(user)) {
+      break;
+    }
     await ship(user);
   }
 }
@@ -190,6 +192,7 @@ await users.find({ _id: { $in: ['4e4e1638c85e808431000003', someObjectId] } }); 
 await users.find({
   _id: { $nin: ['4e4e1638c85e808431000003', '4e4e1638c85e808431000004'] }
 }); // same for $nin
+await users.find({ _id: { $gt: '4e4e1638c85e808431000003' } }); // scalar comparisons too: $eq/$ne/$gt/$gte/$lt/$lte
 ```
 
 Strings that are not valid 24-character hex pass through unchanged, so numeric and UUID `_id` schemes keep working.

--- a/readme.md
+++ b/readme.md
@@ -89,9 +89,9 @@ new MongoClient(server, options?)
 | `removeById(id, options?)`          | `boolean`                              | `false`            |
 | `createIndex(spec, options?)`       | `string \| null`                       | `null`             |
 | `ensureIndexes(specs)`              | `string[]`                             | `[]`               |
-| `oid(value?)`                       | `ObjectId`                             | fresh `ObjectId()` |
+| `oid(value?)`                       | `ObjectId \| input`                    | fresh `ObjectId()` |
 
-All async methods accept `options.signal: AbortSignal` for cancellation. See [AbortSignal](#abortsignal).
+Every async method except `findById` accepts `options.signal: AbortSignal` and `options.timeout: ms` for cancellation (see [AbortSignal and timeout](#abortsignal-and-timeout)) and a per-operation `options.onError` reporter (see [Observability](#observability)); for `ensureIndexes`, pass them inside each entry's `options`. `oid(value?)` is synchronous: it coerces a valid 24-char hex string to `ObjectId`, mints a fresh one for nullish input, and returns anything else untouched.
 
 `save` inserts when `_id` is absent and replaces via `upsert` when present. `saveAll` delegates to `insertMany`; non-object entries are dropped silently.
 
@@ -262,11 +262,11 @@ await pages.update(
 );
 ```
 
-Only `arrayFilters` and `signal` are forwarded; other driver-level update options are ignored. Use `client.open(name)` directly if you need them.
+Only `arrayFilters`, `signal`, and `timeout` are forwarded; other driver-level update options are ignored. Use `client.open(name)` directly if you need them.
 
-## AbortSignal
+## AbortSignal and timeout
 
-Every async method (except `findById`) accepts `options.signal` and forwards it to the driver. Pre-aborted signals collapse to the empty default and emit through `onError`:
+Every async method except `findById` accepts `options.signal` and forwards it to the driver (for `ensureIndexes`, inside each entry's `options`). Pre-aborted signals collapse to the empty default and emit through `onError`:
 
 ```js
 const ctrl = new AbortController();
@@ -274,6 +274,13 @@ setTimeout(() => ctrl.abort(), 200);
 
 const docs = await users.find({}, { signal: ctrl.signal });
 // [] if the operation was aborted before completion
+```
+
+`options.timeout: ms` arms a per-operation deadline (`AbortSignal.timeout` under the hood) and composes with a caller signal via `AbortSignal.any` — the operation aborts when either fires. Non-positive and non-numeric values are ignored.
+
+```js
+const docs = await users.find({}, { timeout: 500, signal: ctrl.signal });
+// [] when the deadline fires first, [] when the caller aborts first
 ```
 
 Aborting mid-iteration of `each()` ends the loop quietly and reports through `onError`.

--- a/readme.md
+++ b/readme.md
@@ -151,7 +151,7 @@ The returned object is a factory — each `for await` opens its own cursor, so t
 
 `each()` exposes only `Symbol.asyncIterator` and `Symbol.asyncDispose`. There is no `close()` method or `cancel()` on the returned object — disposal is the only way to terminate iteration explicitly.
 
-Errors during open or iteration end the loop quietly and report through `onError` (or `console.error`) with `ctx.method === 'each'`. Cursor close errors are reported with `ctx.method === 'each.close'`.
+Errors during open or iteration end the loop quietly and report through the local `options.onError` when one was passed, otherwise through the client-level `onError` (or `console.error`), with `ctx.method === 'each'`. Cursor close errors are reported with `ctx.method === 'each.close'`.
 
 ## Indexes
 
@@ -201,9 +201,43 @@ new MongoClient(url, { silent: true }); // suppress all internal logging
 new MongoClient(url, { onError: (err, ctx) => console.error(ctx.method, err) }); // custom handler
 ```
 
+`silent: true` mutes the whole client-level channel — including a custom client-level `onError`. A per-operation `options.onError` is the one thing it does not suppress (see below).
+
 The `ctx` passed to `onError` has the shape `{ method, collection?, query? }`, e.g. `{ method: 'findOne', collection: 'users', query: { email: 'a@b.c' } }`.
 
-A throwing `onError` is itself caught and ignored; a broken reporter cannot take down the caller.
+Mind what reaches your logs: `ctx.query` is the original query object and may carry PII or secrets, and driver error messages can embed document values too (a duplicate-key `E11000` includes the offending value). The default `console.error` reporter prints only `[easymongo] <collection>.<method> failed:` plus the error — never `ctx.query` — but a custom `onError` owns redaction of everything it forwards.
+
+A throwing `onError` is itself caught and ignored, and a rejected promise from an `async` handler is defused the same way; a broken reporter cannot take down the caller (the rejection is silently dropped, so do your own catching inside async handlers if you care about their failures).
+
+### Per-operation `onError`
+
+Every method that takes `options` also accepts a local `onError(err, ctx)`. When a function is passed, it takes ownership of the error for that one call: the client-level `onError` and the default `console.error` stay silent, and `silent: true` does not suppress it — an explicitly passed callback is a requested channel, not internal logging.
+
+This is the escape hatch for callers that need to know whether _this particular_ operation failed — no shared state, no races between parallel operations, works with a client configured elsewhere:
+
+```js
+let failure = null;
+const docs = await users.find(query, { onError: (err) => (failure = err) });
+if (failure) {
+  throw failure; // re-raising is the caller's decision, not the library's
+}
+```
+
+The same pattern detects a mid-stream cursor error in `each()`, which otherwise just truncates the iteration:
+
+```js
+let failure = null;
+for await (const doc of users.each(query, {
+  onError: (err) => (failure = err)
+})) {
+  // ...
+}
+if (failure) {
+  throw failure; // the stream was cut short
+}
+```
+
+`findById` has no options slot — use `findOne({ _id: id }, { onError })`. For `ensureIndexes`, pass `onError` inside each spec's `options`. A throwing local handler is caught and ignored, same as the client-level one.
 
 ## Empty filter protection
 

--- a/readme.md
+++ b/readme.md
@@ -110,10 +110,13 @@ await users.find(
     limit: 10,
     skip: 0,
     sort: { name: 1 },
+    batchSize: 100,
     fields: ['name', 'email']
   }
 );
 ```
+
+`limit`, `skip`, `sort`, and `batchSize` pass through to the driver (`findOne` takes no `limit` or `batchSize` — it always fetches a single document; `batchSize` bounds how many documents each cursor fetch may buffer, which matters for `each()` over large documents).
 
 Projection accepts three forms:
 
@@ -129,7 +132,7 @@ The array form fails closed: it always produces a projection. Non-string entries
 
 ## Streaming reads
 
-`each(query?, options?)` returns a lazy iterable that opens a cursor on first iteration and closes it when iteration ends. It accepts the same options as `find` (`limit`, `skip`, `sort`, `fields`, `projection`, `signal`).
+`each(query?, options?)` returns a lazy iterable that opens a cursor on first iteration and closes it when iteration ends. It accepts the same options as `find` (`limit`, `skip`, `sort`, `fields`, `projection`, `batchSize`, `signal`, `timeout`, `onError`).
 
 ```js
 for await (const user of users.each({ active: true })) {

--- a/readme.md
+++ b/readme.md
@@ -93,7 +93,7 @@ new MongoClient(server, options?)
 
 Every async method except `findById` accepts `options.signal: AbortSignal` and `options.timeout: ms` for cancellation (see [AbortSignal and timeout](#abortsignal-and-timeout)) and a per-operation `options.onError` reporter (see [Observability](#observability)); for `ensureIndexes`, pass them inside each entry's `options`. `oid(value?)` is synchronous: it coerces a valid 24-char hex string to `ObjectId`, mints a fresh one for nullish input, and returns anything else untouched.
 
-`save` inserts when `_id` is absent and replaces via `upsert` when present. `saveAll` delegates to `insertMany`; non-object entries are dropped silently.
+`save` inserts when `_id` is absent and replaces via `upsert` when present. Documents passed to `save`/`saveAll` get the same `id` → `_id` alias rewrite as queries — a top-level `id` field never reaches the database as a literal field. `saveAll` delegates to an unordered `insertMany`; non-object entries are dropped silently, and on partial failure (e.g. one entry hits a duplicate key) it resolves to the successfully inserted subset instead of `[]`. Non-object input to `save` and non-array input to `saveAll` are rejected and reported, like every other validation reject.
 
 `count({})` short-circuits to `estimatedDocumentCount`, which reads the cached collection size without a full scan. Numbers may be slightly off on sharded collections with orphans or after an unclean shutdown, but the path is roughly two orders of magnitude faster.
 
@@ -188,6 +188,10 @@ await users.find({
 ```
 
 Strings that are not valid 24-character hex pass through unchanged, so numeric and UUID `_id` schemes keep working.
+
+`findById`/`removeById` reject `null`, `undefined`, and plain-object ids before the driver sees them (reported as `Invalid id rejected`): an operator object like `{ $ne: null }` smuggled from request input would otherwise match — or delete — an arbitrary document. Use `findOne({ _id: { ... } })` for intentional operator queries.
+
+Apart from this id normalization, query objects are passed to the driver **unsanitized** — that is the point of a thin wrapper. Never feed raw request input (`req.body`, `req.query`) into a query position; validate and build the filter yourself.
 
 ## Observability
 

--- a/test/abort-signal.js
+++ b/test/abort-signal.js
@@ -48,6 +48,8 @@ describe('AbortSignal — pre-aborted collapses to empty default', () => {
       assert.deepEqual(result, []);
       assert.equal(captured.length, 1);
       assert.equal(captured[0].ctx.method, 'find');
+      // The abort itself must be reported, not an unrelated failure.
+      assert.match(captured[0].err.name, /Abort|MongoAPIError/);
     });
   });
 
@@ -164,6 +166,19 @@ describe('AbortSignal — pre-aborted collapses to empty default', () => {
       assert.equal(captured[0].ctx.method, 'removeById');
     });
   });
+
+  test('createIndex returns null', async () => {
+    await withClient(async (mongo, captured) => {
+      const col = mongo.collection(COLLECTION);
+      const result = await col.createIndex(
+        { aborted: 1 },
+        { signal: abortedSignal() }
+      );
+      assert.equal(result, null);
+      assert.equal(captured.length, 1);
+      assert.equal(captured[0].ctx.method, 'createIndex');
+    });
+  });
 });
 
 describe('AbortSignal — aborting mid-flight', () => {
@@ -174,13 +189,11 @@ describe('AbortSignal — aborting mid-flight', () => {
       await col.saveAll(docs);
 
       const ctrl = new AbortController();
-      // Schedule abort to fire on next tick — most network calls will see it.
       queueMicrotask(() => ctrl.abort());
       const result = await col.find({}, { signal: ctrl.signal });
 
-      // Either the find finished synchronously and returns [...all] OR
-      // it was aborted and returns []. Both are valid fail-silent outcomes;
-      // we only assert that no error escapes.
+      // Racy by design: the find may finish before the abort lands. Both
+      // outcomes are valid fail-silent results; only assert no error escapes.
       assert.ok(Array.isArray(result));
       assert.ok(captured.length === 0 || captured[0].ctx.method === 'find');
     });
@@ -229,6 +242,88 @@ describe('AbortSignal — caller can detect abort via signal.aborted', () => {
       const result = await col.find({}, { signal: ctrl.signal });
       assert.deepEqual(result, []);
       assert.equal(ctrl.signal.aborted, true);
+    });
+  });
+});
+
+// $where busy-waits per document (mongo evaluates it document-by-document),
+// making the query reliably slower than a small timeout, so the deadline fires.
+const SLOW_WHERE =
+  'var t = Date.now(); while (Date.now() - t < 120) {} return true;';
+
+describe('timeout option — deadline cancels a slow operation', () => {
+  test('find collapses to [] when the timeout fires', async () => {
+    await withClient(async (mongo, captured) => {
+      const col = mongo.collection(COLLECTION);
+      await col.saveAll([{ n: 1 }, { n: 2 }, { n: 3 }]);
+      const result = await col.find({ $where: SLOW_WHERE }, { timeout: 30 });
+      assert.deepEqual(result, []);
+      assert.equal(captured[0]?.ctx.method, 'find');
+    });
+  });
+
+  test('count collapses to 0 when the timeout fires (withSignal path)', async () => {
+    await withClient(async (mongo) => {
+      const col = mongo.collection(COLLECTION);
+      await col.saveAll([{ n: 1 }, { n: 2 }, { n: 3 }]);
+      const result = await col.count({ $where: SLOW_WHERE }, { timeout: 30 });
+      assert.equal(result, 0);
+    });
+  });
+
+  test('update collapses to false when the timeout fires', async () => {
+    await withClient(async (mongo) => {
+      const col = mongo.collection(COLLECTION);
+      await col.saveAll([{ n: 1 }, { n: 2 }, { n: 3 }]);
+      const result = await col.update(
+        { $where: SLOW_WHERE },
+        { $set: { hit: true } },
+        { timeout: 30 }
+      );
+      assert.equal(result, false);
+    });
+  });
+});
+
+describe('timeout option — composes and stays out of the way', () => {
+  test('a fast operation under a generous timeout returns normally', async () => {
+    await withClient(async (mongo) => {
+      const col = mongo.collection(COLLECTION);
+      await col.saveAll([{ name: 'A' }, { name: 'B' }]);
+      const result = await col.find({}, { timeout: 5000 });
+      assert.equal(result.length, 2);
+    });
+  });
+
+  test('a pre-aborted caller signal wins over a generous timeout', async () => {
+    await withClient(async (mongo, captured) => {
+      const col = mongo.collection(COLLECTION);
+      await col.save({ name: 'A' });
+      const result = await col.find(
+        {},
+        { signal: abortedSignal(), timeout: 5000 }
+      );
+      assert.deepEqual(result, []);
+      assert.equal(captured[0]?.ctx.method, 'find');
+    });
+  });
+
+  test('non-positive timeout is ignored', async () => {
+    await withClient(async (mongo) => {
+      const col = mongo.collection(COLLECTION);
+      await col.saveAll([{ name: 'A' }, { name: 'B' }]);
+      assert.equal((await col.find({}, { timeout: 0 })).length, 2);
+      assert.equal((await col.find({}, { timeout: -5 })).length, 2);
+    });
+  });
+
+  test('createIndex under a generous timeout creates the index, and timeout never reaches the driver', async () => {
+    await withClient(async (mongo) => {
+      const col = mongo.collection(COLLECTION);
+      const name = await col.createIndex({ timed: 1 }, { timeout: 5000 });
+      assert.equal(typeof name, 'string');
+      const native = await mongo.open(COLLECTION);
+      await native.dropIndex(name);
     });
   });
 });

--- a/test/array-filters.js
+++ b/test/array-filters.js
@@ -71,7 +71,6 @@ describe('update with arrayFilters', () => {
 
   test('only arrayFilters is forwarded — other options ignored', async () => {
     await articles.save({ name: 'A', count: 1 });
-    // upsert: true should NOT take effect — not in whitelist.
     const ok = await articles.update(
       { name: 'NoSuch' },
       { $set: { count: 99 } },
@@ -87,10 +86,10 @@ describe('update with arrayFilters', () => {
       { dbname: 'test' },
       { onError: (err, ctx) => captured.push({ err, ctx }) }
     );
-    const localArticles = local.collection(COLLECTION);
+    const col = local.collection(COLLECTION);
 
-    await localArticles.save({ name: 'A', items: [{ kind: 'x' }] });
-    const ok = await localArticles.update(
+    await col.save({ name: 'A', items: [{ kind: 'x' }] });
+    const ok = await col.update(
       { name: 'A' },
       { $set: { 'items.$[el].kind': 'y' } },
       { arrayFilters: [{ 'el.kind': 'x' }, { 'el.kind': 'extra-unused' }] }

--- a/test/client.js
+++ b/test/client.js
@@ -41,7 +41,7 @@ test('open() races close(): collection method emits with explicit error message'
   const messages = captured.map((c) => c.err?.message ?? '');
   // Either the dedicated guard fired, or the driver itself rejected the
   // closed connection; both paths must surface a useful message.
-  const hasUseful = messages.some(
+  const useful = messages.some(
     (m) =>
       /client closed during open/i.test(m) ||
       /closed/i.test(m) ||
@@ -49,9 +49,58 @@ test('open() races close(): collection method emits with explicit error message'
       /Topology/i.test(m)
   );
   assert.ok(
-    hasUseful,
+    useful,
     `expected a meaningful close-related error, got: ${messages.join(' | ')}`
   );
+});
+
+test('open() guard: connect settling after close() collapses to the empty default', async () => {
+  const captured = [];
+  const mongo = new MongoClient(
+    { dbname: 'test' },
+    { onError: (err, ctx) => captured.push({ err, ctx }) }
+  );
+
+  // Deterministic interleaving: connect settles after close() cleared state,
+  // so open() must hit its `!this.db` guard instead of using a torn-down client.
+  mongo._connecting = Promise.resolve();
+  mongo.client = null;
+  mongo.db = null;
+
+  const result = await mongo.collection('easymongo_guard').count({ x: 1 });
+
+  assert.equal(result, 0, 'collapsed to empty default');
+  assert.equal(captured.length, 1);
+  assert.equal(captured[0].err.message, 'Client closed during open');
+  assert.equal(captured[0].ctx.method, 'count');
+  await mongo.close();
+});
+
+test('close(): native close error is swallowed and reported as {method: close}', async () => {
+  const captured = [];
+  const mongo = new MongoClient(
+    { dbname: 'test' },
+    { onError: (err, ctx) => captured.push({ err, ctx }) }
+  );
+  await mongo.collection('easymongo_close_err').count();
+
+  const native = mongo.client;
+  const original = native.close.bind(native);
+  native.close = async () => {
+    throw new Error('boom on close');
+  };
+
+  await mongo.close();
+
+  assert.equal(captured.length, 1);
+  assert.equal(captured[0].err.message, 'boom on close');
+  assert.deepEqual(captured[0].ctx, { method: 'close' });
+  assert.equal(mongo.client, null);
+  assert.equal(mongo.db, null);
+
+  // Release the connection the throwing stub left open, or the test process
+  // never exits.
+  await original();
 });
 
 test('close() racing with reopen closes both clients', async () => {
@@ -60,10 +109,10 @@ test('close() racing with reopen closes both clients', async () => {
   const clientA = mongo.client;
 
   let closeACalls = 0;
-  const origAClose = clientA.close.bind(clientA);
+  const closeA = clientA.close.bind(clientA);
   clientA.close = async (...args) => {
     closeACalls = closeACalls + 1;
-    return origAClose(...args);
+    return closeA(...args);
   };
 
   const firstClose = mongo.close();
@@ -75,10 +124,10 @@ test('close() racing with reopen closes both clients', async () => {
   assert.notEqual(clientA, clientB, 'reopen produced a fresh native client');
 
   let closeBCalls = 0;
-  const origBClose = clientB.close.bind(clientB);
+  const closeB = clientB.close.bind(clientB);
   clientB.close = async (...args) => {
     closeBCalls = closeBCalls + 1;
-    return origBClose(...args);
+    return closeB(...args);
   };
 
   const secondClose = mongo.close();
@@ -93,7 +142,6 @@ test('close() racing with reopen closes both clients', async () => {
 
 test('concurrent close() calls share one teardown', async () => {
   const mongo = new MongoClient({ dbname: 'test' }, { silent: true });
-  // Open the connection so close() actually has work to do.
   await mongo.collection('easymongo_close_share').count();
 
   let closeCount = 0;

--- a/test/dispose.js
+++ b/test/dispose.js
@@ -35,7 +35,7 @@ test('await using triggers close at scope end', async () => {
   assert.equal(captured.client, null);
   assert.equal(captured.db, null);
 
-  // Cleanup leftover document via a fresh client.
+  // Wipe via the native driver — remove({}) is blocked by the empty-filter guard.
   const cleaner = new MongoClient({ dbname: 'test' }, { silent: true });
   const native = await cleaner.open(collection);
   await native.deleteMany({});

--- a/test/each.js
+++ b/test/each.js
@@ -337,6 +337,27 @@ describe('each — AbortSignal', () => {
       }
     }
     assert.ok(n >= 5);
+    assert.ok(n < 200, 'abort must stop iteration early');
     await local.close();
+  });
+
+  test('options.timeout collapses iteration to an empty result and reports', async () => {
+    await seed(3);
+    const captured = [];
+
+    // $where burns >timeout per document server-side, so the deadline armed by
+    // the wrapper fires mid-query.
+    const SLOW_WHERE =
+      'var t = new Date(); while (new Date() - t < 120) {} return true;';
+    const out = [];
+    for await (const doc of items.each(
+      { $where: SLOW_WHERE },
+      { timeout: 30, onError: (err, ctx) => captured.push(ctx.method) }
+    )) {
+      out.push(doc);
+    }
+
+    assert.deepEqual(out, []);
+    assert.deepEqual(captured, ['each']);
   });
 });

--- a/test/each.js
+++ b/test/each.js
@@ -158,6 +158,24 @@ describe('each — lifecycle', () => {
     await cursor[Symbol.asyncDispose]();
     // No throw, no escaped error.
   });
+
+  test('Symbol.asyncDispose closes a live mid-iteration cursor', async () => {
+    // More docs than one server batch so the cursor stays open after a single
+    // next() — dispose must close a genuinely live cursor, not an empty set.
+    await seed(300);
+    const cursor = items.each({});
+    const it = cursor[Symbol.asyncIterator]();
+
+    const first = await it.next();
+    assert.equal(first.done, false);
+
+    await cursor[Symbol.asyncDispose]();
+
+    // next() on a disposed cursor ends instead of throwing; the client stays usable.
+    const second = await it.next();
+    assert.equal(second.done, true);
+    assert.equal(await items.count(), 300);
+  });
 });
 
 describe('each — fail-silent', () => {
@@ -236,6 +254,61 @@ describe('each — concurrent iteration on the same cursor', () => {
     assert.equal(first.length, 15);
     assert.equal(second.length, 15);
   });
+});
+
+describe('each — abandoned iterators are reclaimed by GC', () => {
+  // Requires --expose-gc (the test/coverage scripts pass it); skipped otherwise.
+  test(
+    'GC closes cursors of iterators abandoned mid-iteration',
+    { skip: !globalThis.gc },
+    async () => {
+      // More docs than one server batch (~101) so a single next() leaves the
+      // cursor live and pinned server-side instead of exhausting it at once.
+      await seed(500);
+      // Ensure the native client (and its active-cursor set) exists.
+      await items.count();
+      const activeCursors = mongo.client?.s?.activeCursors;
+
+      async function abandon() {
+        const it = items.each({})[Symbol.asyncIterator]();
+        await it.next(); // opens the cursor, suspends at the first yield
+        // `it` goes out of scope with no break/return/dispose
+      }
+
+      for (let i = 0; i < 25; i = i + 1) {
+        // oxlint-disable-next-line no-await-in-loop
+        await abandon();
+      }
+
+      if (activeCursors) {
+        assert.ok(
+          activeCursors.size >= 15,
+          `cursors stay pinned before GC (size ${activeCursors.size})`
+        );
+      }
+
+      // Force GC, then let the FinalizationRegistry callbacks — and the async
+      // cursor.close() they trigger — run.
+      const tick = (ms) =>
+        new Promise((resolve) => {
+          setTimeout(resolve, ms);
+        });
+      for (let i = 0; i < 5; i = i + 1) {
+        globalThis.gc();
+        // oxlint-disable-next-line no-await-in-loop
+        await tick(10);
+      }
+      await tick(50);
+
+      if (activeCursors) {
+        assert.ok(
+          activeCursors.size <= 2,
+          `cursors released after GC (size ${activeCursors.size})`
+        );
+      }
+      assert.equal(await items.count(), 500);
+    }
+  );
 });
 
 describe('each — local onError', () => {

--- a/test/each.js
+++ b/test/each.js
@@ -121,7 +121,6 @@ describe('each — lifecycle', () => {
   test('await using is safe with no iteration', async () => {
     {
       await using _cursor = items.each({});
-      // Never iterated — dispose still cleans up safely.
     }
     assert.equal(await items.count(), 0);
   });
@@ -156,7 +155,6 @@ describe('each — lifecycle', () => {
     const cursor = items.each({});
     await cursor[Symbol.asyncDispose]();
     await cursor[Symbol.asyncDispose]();
-    // No throw, no escaped error.
   });
 
   test('Symbol.asyncDispose closes a live mid-iteration cursor', async () => {
@@ -236,11 +234,7 @@ describe('each — concurrent iteration on the same cursor', () => {
     const sessionErrors = captured.filter((c) =>
       /session that has ended/i.test(c.err?.message ?? '')
     );
-    assert.equal(
-      sessionErrors.length,
-      0,
-      'no spurious session-ended errors after factory model fix'
-    );
+    assert.equal(sessionErrors.length, 0, 'no spurious session-ended errors');
     await local.close();
   });
 

--- a/test/each.js
+++ b/test/each.js
@@ -238,6 +238,69 @@ describe('each — concurrent iteration on the same cursor', () => {
   });
 });
 
+describe('each — local onError', () => {
+  test('connection error routes to the local handler only', async () => {
+    let clientCalled = 0;
+    const broken = new MongoClient(
+      'mongodb://127.0.0.1:1/test?serverSelectionTimeoutMS=300',
+      {
+        onError: () => {
+          clientCalled = clientCalled + 1;
+        }
+      }
+    );
+
+    const captured = [];
+    const seen = await collect(
+      broken
+        .collection('whatever')
+        .each({}, { onError: (err, ctx) => captured.push(ctx.method) })
+    );
+
+    assert.deepEqual(seen, []);
+    assert.deepEqual(captured, ['each']);
+    assert.equal(clientCalled, 0);
+    await broken.close();
+  });
+
+  test('mid-stream abort routes to the local handler', async () => {
+    await seed(200);
+    let clientCalled = 0;
+    const local = new MongoClient(
+      { dbname: 'test' },
+      {
+        onError: () => {
+          clientCalled = clientCalled + 1;
+        }
+      }
+    );
+
+    const captured = [];
+    const ctrl = new AbortController();
+    let n = 0;
+    for await (const _doc of local.collection(COLLECTION).each(
+      {},
+      {
+        signal: ctrl.signal,
+        onError: (err, ctx) => captured.push(ctx.method)
+      }
+    )) {
+      n = n + 1;
+      if (n === 5) {
+        ctrl.abort();
+      }
+    }
+
+    assert.ok(n >= 5);
+    assert.ok(
+      captured.includes('each'),
+      'mid-stream error must reach the local handler'
+    );
+    assert.equal(clientCalled, 0, 'client onError must stay silent');
+    await local.close();
+  });
+});
+
 describe('each — AbortSignal', () => {
   test('pre-aborted signal yields nothing and emits', async () => {
     await seed(20);

--- a/test/index.js
+++ b/test/index.js
@@ -231,6 +231,12 @@ describe('distinct', () => {
     const result = await users.distinct('tag', { g: 1 });
     assert.deepEqual(result.sort(), ['a', 'b']);
   });
+
+  test('non-array driver result collapses to []', async (t) => {
+    const native = await mongo.open(COLLECTION);
+    t.mock.method(native, 'distinct', async () => null);
+    assert.deepEqual(await users.distinct('tag'), []);
+  });
 });
 
 describe('save', () => {
@@ -264,6 +270,12 @@ describe('save', () => {
     assert.equal(result._id.toString(), hex);
     assert.equal(result.id, undefined);
     assert.equal(await users.count(), 1);
+  });
+
+  test('missing insertedId from the driver collapses to null', async (t) => {
+    const native = await mongo.open(COLLECTION);
+    t.mock.method(native, 'insertOne', async () => ({}));
+    assert.equal(await users.save({ name: 'ghost' }), null);
   });
 });
 
@@ -326,6 +338,12 @@ describe('update', () => {
     for (const doc of all) {
       assert.equal(doc.url, 'simonenko.xyz');
     }
+  });
+
+  test('false when matched but nothing modified', async () => {
+    await users.save({ name: 'Alexey', url: 'x' });
+    const ok = await users.update({ name: 'Alexey' }, { $set: { url: 'x' } });
+    assert.equal(ok, false);
   });
 });
 
@@ -495,9 +513,9 @@ describe('empty filter guard', () => {
       { dbname: 'test' },
       { onError: (err, ctx) => captured.push({ err, ctx }) }
     );
-    const localUsers = local.collection(COLLECTION);
+    const col = local.collection(COLLECTION);
 
-    await localUsers.update(null, { $set: { x: 1 } });
+    await col.update(null, { $set: { x: 1 } });
 
     assert.equal(captured.length, 1);
     assert.equal(captured[0].ctx.method, 'update');
@@ -513,9 +531,9 @@ describe('empty filter guard', () => {
       { dbname: 'test' },
       { onError: (err, ctx) => captured.push({ err, ctx }) }
     );
-    const localUsers = local.collection(COLLECTION);
+    const col = local.collection(COLLECTION);
 
-    await localUsers.remove({});
+    await col.remove({});
 
     assert.equal(captured.length, 1);
     assert.equal(captured[0].ctx.method, 'remove');
@@ -534,9 +552,9 @@ describe('empty filter guard', () => {
         onError: (err, ctx) => captured.push({ err, ctx })
       }
     );
-    const localUsers = local.collection(COLLECTION);
+    const col = local.collection(COLLECTION);
 
-    const ok = await localUsers.remove(null);
+    const ok = await col.remove(null);
     assert.equal(ok, false);
     assert.equal(captured.length, 0);
 
@@ -702,9 +720,9 @@ describe('saveAll partial recovery', () => {
         onError: (err, ctx) => captured.push({ err, ctx })
       }
     );
-    const localUsers = local.collection(COLLECTION);
+    const col = local.collection(COLLECTION);
 
-    const result = await localUsers.saveAll([
+    const result = await col.saveAll([
       { name: 'A' },
       { _id: first._id, name: 'X-dupe' },
       { name: 'B' }

--- a/test/index.js
+++ b/test/index.js
@@ -633,6 +633,22 @@ describe('read options', () => {
     assert.equal(junk[0].name, undefined);
     assert.equal(junk[0].secret, undefined);
   });
+
+  test('batchSize is forwarded to the driver', async (t) => {
+    await users.saveAll([{ n: 1 }, { n: 2 }, { n: 3 }]);
+
+    const native = await mongo.open(COLLECTION);
+    const original = native.find.bind(native);
+    let seen = null;
+    t.mock.method(native, 'find', (filter, opts) => {
+      seen = opts;
+      return original(filter, opts);
+    });
+
+    const result = await users.find({}, { batchSize: 2 });
+    assert.equal(result.length, 3);
+    assert.equal(seen?.batchSize, 2);
+  });
 });
 
 describe('oid', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -578,6 +578,29 @@ describe('read options', () => {
     assert.equal(result[0].n, 2);
     assert.equal(result[1].n, 3);
   });
+
+  test('empty fields array fails closed to an _id-only projection', async () => {
+    await users.save({ name: 'Alexey', secret: 'shh' });
+    const result = await users.find({}, { fields: [] });
+    assert.equal(result.length, 1);
+    assert.ok(result[0]._id instanceof ObjectId);
+    assert.equal(result[0].name, undefined);
+    assert.equal(result[0].secret, undefined);
+  });
+
+  test('fields array with no usable entries fails closed (whitelist cannot be disabled)', async () => {
+    await users.save({ name: 'Alexey', secret: 'shh' });
+
+    const smuggled = await users.find({}, { fields: ['__proto__'] });
+    assert.equal(smuggled.length, 1);
+    assert.equal(smuggled[0].name, undefined);
+    assert.equal(smuggled[0].secret, undefined);
+
+    const junk = await users.find({}, { fields: [42, null] });
+    assert.equal(junk.length, 1);
+    assert.equal(junk[0].name, undefined);
+    assert.equal(junk[0].secret, undefined);
+  });
 });
 
 describe('oid', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -86,11 +86,43 @@ describe('count', () => {
       { name: 'C', age: 40 },
       { name: 'D', age: 25 }
     ]);
-    // countDocuments does not accept $where (it builds an aggregation
-    // pipeline and $where is disallowed inside $match). Wrapper must
-    // detect the error and fall back to a real query.
+    // countDocuments rejects $where ($where is disallowed inside its $match
+    // aggregation stage), so the wrapper must fall back to a real query.
     const n = await users.count({ $where: 'this.age > 30' });
     assert.equal(n, 2);
+  });
+
+  test('falls back for Location* uassert codes', async (t) => {
+    await users.saveAll([{ a: 1 }, { a: 2 }]);
+
+    const native = await mongo.open(COLLECTION);
+    t.mock.method(native, 'countDocuments', async () => {
+      const err = new Error('synthetic uassert');
+      err.name = 'MongoServerError';
+      err.code = 5626500;
+      err.codeName = 'Location5626500';
+      throw err;
+    });
+
+    assert.equal(await users.count({ a: { $gte: 1 } }), 2);
+  });
+
+  test('does not fall back to a scan for non-query-shape errors', async (t) => {
+    await users.saveAll([{ a: 1 }, { a: 2 }]);
+
+    const native = await mongo.open(COLLECTION);
+    let findCalls = 0;
+    t.mock.method(native, 'countDocuments', async () => {
+      throw new Error('transient network failure');
+    });
+    t.mock.method(native, 'find', () => {
+      findCalls = findCalls + 1;
+      throw new Error('fallback scan must not run');
+    });
+
+    const result = await users.count({ a: 1 });
+    assert.equal(result, 0);
+    assert.equal(findCalls, 0, 'find not called for a non-MongoServerError');
   });
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -248,6 +248,31 @@ describe('saveAll', () => {
     assert.deepEqual(await users.saveAll([]), []);
     assert.deepEqual(await users.saveAll(null), []);
   });
+
+  test('non-object entries are dropped, objects survive', async () => {
+    const result = await users.saveAll([{ a: 1 }, 'junk', null, 42, { b: 2 }]);
+    assert.equal(result.length, 2);
+    for (const doc of result) {
+      assert.ok(doc._id instanceof ObjectId);
+    }
+    assert.equal(await users.count(), 2);
+  });
+
+  test('array of only non-object entries returns [] without inserting', async () => {
+    assert.deepEqual(await users.saveAll(['junk', 42, null]), []);
+    assert.equal(await users.count(), 0);
+  });
+
+  test('caller-supplied _id survives the happy path', async () => {
+    const id = users.oid();
+    const result = await users.saveAll([
+      { _id: id, name: 'pinned' },
+      { name: 'auto' }
+    ]);
+    assert.equal(result.length, 2);
+    const pinned = result.find((d) => d.name === 'pinned');
+    assert.equal(pinned._id, id);
+  });
 });
 
 describe('update', () => {
@@ -394,6 +419,41 @@ describe('empty filter guard', () => {
   test('remove with explicit query still works (control)', async () => {
     await users.saveAll([{ name: 'A' }, { name: 'B' }]);
     assert.equal(await users.remove({ name: 'A' }), true);
+    assert.equal(await users.count(), 1);
+  });
+
+  test('filter with only undefined values is rejected (update)', async () => {
+    await users.saveAll([{ name: 'A' }, { name: 'B' }]);
+    // {name: undefined} would serialize to {name: null}, which matches docs
+    // where the field is missing — effectively an empty filter.
+    const result = await users.update(
+      { name: undefined },
+      { $set: { url: 'x' } }
+    );
+    assert.equal(result, false);
+    const all = await users.find();
+    for (const doc of all) {
+      assert.equal(doc.url, undefined);
+    }
+  });
+
+  test('filter with only undefined values is rejected (remove)', async () => {
+    await users.saveAll([{ name: 'A' }, { other: 1 }]);
+    assert.equal(await users.remove({ name: undefined }), false);
+    assert.equal(await users.count(), 2);
+  });
+
+  test('filter mixing undefined and defined keys still works', async () => {
+    await users.saveAll([{ name: 'A' }, { name: 'B' }]);
+    assert.equal(await users.remove({ name: 'A', ghost: undefined }), true);
+    assert.equal(await users.count(), 1);
+  });
+
+  test('null-prototype filter is accepted', async () => {
+    await users.saveAll([{ name: 'A' }, { name: 'B' }]);
+    const filter = Object.create(null);
+    filter.name = 'A';
+    assert.equal(await users.remove(filter), true);
     assert.equal(await users.count(), 1);
   });
 
@@ -591,6 +651,20 @@ describe('saveAll partial recovery', () => {
     assert.equal(captured[0].ctx.collection, COLLECTION);
 
     await local.close();
+  });
+
+  test('partial recovery preserves a caller-supplied _id', async () => {
+    const first = await users.save({ name: 'X' });
+    const id = users.oid();
+
+    const result = await users.saveAll([
+      { _id: first._id, name: 'dupe' },
+      { _id: id, name: 'B' }
+    ]);
+
+    assert.equal(result.length, 1);
+    assert.equal(result[0].name, 'B');
+    assert.equal(result[0]._id.toString(), id.toString());
   });
 
   test('all conflict: returns []', async () => {

--- a/test/index.js
+++ b/test/index.js
@@ -149,6 +149,21 @@ describe('findById', () => {
     assert.equal(result.name, 'Alexey');
     assert.equal(result.secret, undefined);
   });
+
+  test('rejects nullish id', async () => {
+    await users.save({ name: 'Alexey' });
+    assert.equal(await users.findById(undefined), null);
+    assert.equal(await users.findById(null), null);
+  });
+
+  test('rejects plain-object id (operator smuggling)', async () => {
+    await users.save({ name: 'Alexey' });
+    assert.equal(await users.findById({ $ne: null }), null);
+    assert.equal(
+      await users.findById({ id: '4e4e1638c85e808431000003' }),
+      null
+    );
+  });
 });
 
 describe('exists', () => {
@@ -207,6 +222,16 @@ describe('save', () => {
     assert.equal(await users.save(null), null);
     assert.equal(await users.save('not a doc'), null);
     assert.equal(await users.save(42), null);
+  });
+
+  test('aliases top-level id field to _id', async () => {
+    const hex = '4e4e1638c85e808431000003';
+    const result = await users.save({ id: hex, name: 'Alexey' });
+    assert.ok(result);
+    assert.ok(result._id instanceof ObjectId);
+    assert.equal(result._id.toString(), hex);
+    assert.equal(result.id, undefined);
+    assert.equal(await users.count(), 1);
   });
 });
 
@@ -273,6 +298,42 @@ describe('removeById', () => {
   test('accepts ObjectId', async () => {
     const created = await users.save({ name: 'Alexey' });
     assert.equal(await users.removeById(created._id), true);
+  });
+
+  test('rejects nullish id', async () => {
+    await users.save({ name: 'Alexey' });
+    assert.equal(await users.removeById(undefined), false);
+    assert.equal(await users.removeById(null), false);
+    assert.equal(await users.count(), 1);
+  });
+
+  test('rejects plain-object id (operator smuggling)', async () => {
+    await users.save({ name: 'Alexey' });
+    assert.equal(await users.removeById({ $ne: null }), false);
+    assert.equal(
+      await users.removeById({ $gte: users.oid('0'.repeat(24)) }),
+      false
+    );
+    assert.equal(await users.count(), 1);
+  });
+
+  test('onError receives ctx for rejected id', async () => {
+    const captured = [];
+    const local = new MongoClient(
+      { dbname: 'test' },
+      { onError: (err, ctx) => captured.push({ err, ctx }) }
+    );
+    const col = local.collection(COLLECTION);
+
+    await col.removeById({ $ne: null });
+    await col.findById(undefined);
+
+    assert.equal(captured.length, 2);
+    assert.equal(captured[0].ctx.method, 'removeById');
+    assert.equal(captured[1].ctx.method, 'findById');
+    assert.match(captured[0].err.message, /invalid id/i);
+
+    await local.close();
   });
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -638,18 +638,44 @@ describe('read options', () => {
     assert.equal(result[0].secret, undefined);
   });
 
-  test('fields array with no usable entries fails closed (whitelist cannot be disabled)', async () => {
+  test('fields array with no usable entries fails closed (whitelist cannot be disabled)', async (t) => {
     await users.save({ name: 'Alexey', secret: 'shh' });
 
+    const native = await mongo.open(COLLECTION);
+    const original = native.find.bind(native);
+    const projections = [];
+    t.mock.method(native, 'find', (filter, opts) => {
+      projections.push(opts?.projection);
+      return original(filter, opts);
+    });
+
+    // `['__proto__']` must collapse to `{_id: 1}`, not `{__proto__: 1}`: the
+    // null-prototype projection object would otherwise turn `__proto__` into a
+    // real own key, leaking a stored `__proto__` field past the whitelist.
     const smuggled = await users.find({}, { fields: ['__proto__'] });
     assert.equal(smuggled.length, 1);
     assert.equal(smuggled[0].name, undefined);
     assert.equal(smuggled[0].secret, undefined);
+    assert.deepEqual({ ...projections.at(-1) }, { _id: 1 });
 
     const junk = await users.find({}, { fields: [42, null] });
     assert.equal(junk.length, 1);
     assert.equal(junk[0].name, undefined);
     assert.equal(junk[0].secret, undefined);
+    assert.deepEqual({ ...projections.at(-1) }, { _id: 1 });
+  });
+
+  test('a stored __proto__ field is not leaked by the array whitelist', async () => {
+    // A document with a field literally named `__proto__` (own key, not the
+    // prototype slot) is the only case where `{__proto__: 1}` and `{_id: 1}`
+    // diverge — prove the whitelist fails closed against it.
+    const native = await mongo.open(COLLECTION);
+    await native.insertOne({ name: 'Alexey', ['__proto__']: 'leak' });
+
+    const result = await users.find({}, { fields: ['__proto__'] });
+    assert.equal(result.length, 1);
+    assert.equal(Object.hasOwn(result[0], '__proto__'), false);
+    assert.equal(result[0].name, undefined);
   });
 
   test('batchSize is forwarded to the driver', async (t) => {

--- a/test/indexes.js
+++ b/test/indexes.js
@@ -282,6 +282,20 @@ describe('ensureIndexes', () => {
     await dropAllNonId();
   });
 
+  test('hostile getter on an entry is skipped, the rest are processed', async () => {
+    const names = await items.ensureIndexes([
+      {
+        get key() {
+          throw new Error('hostile key getter');
+        }
+      },
+      { key: { district: 1 } }
+    ]);
+
+    assert.equal(names.length, 1);
+    assert.match(names[0], /district/);
+  });
+
   test('per-spec onError routes the conflict locally', async () => {
     let clientCalled = 0;
     const local = new MongoClient(

--- a/test/indexes.js
+++ b/test/indexes.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { randomUUID } from 'node:crypto';
-import { describe, test, before, after } from 'node:test';
+import { describe, test, before, after, beforeEach } from 'node:test';
 
 import { MongoClient } from '../lib/index.js';
 
@@ -16,7 +16,13 @@ async function listIndexNames() {
 
 async function dropAllNonId() {
   const native = await mongo.open(COLLECTION);
-  const idx = await native.indexes();
+  let idx;
+  try {
+    idx = await native.indexes();
+  } catch {
+    // The collection does not exist yet (first beforeEach) — nothing to drop.
+    return;
+  }
   await Promise.all(
     idx.filter((i) => i.name !== '_id_').map((i) => native.dropIndex(i.name))
   );
@@ -26,6 +32,10 @@ before(async () => {
   const native = await mongo.open(COLLECTION);
   await native.deleteMany({});
 });
+
+// Cleanup runs BEFORE each test, not at the end of the test body: a mid-test
+// assertion failure must not leak indexes into the following tests.
+beforeEach(dropAllNonId);
 
 after(async () => {
   await dropAllNonId();
@@ -41,14 +51,12 @@ describe('createIndex', () => {
     assert.match(name, /uri/);
     const names = await listIndexNames();
     assert.ok(names.includes(name));
-    await dropAllNonId();
   });
 
   test('idempotent: same spec twice returns same name', async () => {
     const a = await items.createIndex({ tag: 1 });
     const b = await items.createIndex({ tag: 1 });
     assert.equal(a, b);
-    await dropAllNonId();
   });
 
   test('returns null and emits on conflicting options for same key', async () => {
@@ -57,20 +65,16 @@ describe('createIndex', () => {
       { dbname: 'test' },
       { onError: (err, ctx) => captured.push({ err, ctx }) }
     );
-    const localItems = local.collection(COLLECTION);
+    const col = local.collection(COLLECTION);
 
-    await localItems.createIndex({ name: 1 }, { unique: true });
-    const conflicting = await localItems.createIndex(
-      { name: 1 },
-      { unique: false }
-    );
+    await col.createIndex({ name: 1 }, { unique: true });
+    const conflicting = await col.createIndex({ name: 1 }, { unique: false });
 
     assert.equal(conflicting, null);
     assert.equal(captured.length, 1);
     assert.equal(captured[0].ctx.method, 'createIndex');
     assert.equal(captured[0].ctx.collection, COLLECTION);
 
-    await dropAllNonId();
     await local.close();
   });
 
@@ -80,10 +84,10 @@ describe('createIndex', () => {
       { dbname: 'test' },
       { onError: (err, ctx) => captured.push({ err, ctx }) }
     );
-    const localItems = local.collection(COLLECTION);
+    const col = local.collection(COLLECTION);
 
-    assert.equal(await localItems.createIndex(null), null);
-    assert.equal(await localItems.createIndex(42), null);
+    assert.equal(await col.createIndex(null), null);
+    assert.equal(await col.createIndex(42), null);
     assert.equal(captured.length, 2);
     for (const c of captured) {
       assert.equal(c.ctx.method, 'createIndex');
@@ -189,7 +193,6 @@ describe('ensureIndexes', () => {
     for (const n of names) {
       assert.ok(all.includes(n));
     }
-    await dropAllNonId();
   });
 
   test('idempotent on second invocation', async () => {
@@ -202,7 +205,6 @@ describe('ensureIndexes', () => {
       { key: { tags: 1 } }
     ]);
     assert.deepEqual(first.sort(), second.sort());
-    await dropAllNonId();
   });
 
   test('skips conflicts but continues with the rest', async () => {
@@ -211,11 +213,11 @@ describe('ensureIndexes', () => {
       { dbname: 'test' },
       { onError: (err, ctx) => captured.push({ err, ctx }) }
     );
-    const localItems = local.collection(COLLECTION);
+    const col = local.collection(COLLECTION);
 
-    await localItems.createIndex({ slug: 1 }, { unique: true });
+    await col.createIndex({ slug: 1 }, { unique: true });
 
-    const names = await localItems.ensureIndexes([
+    const names = await col.ensureIndexes([
       { key: { slug: 1 }, options: { unique: false } }, // conflicts → skip
       { key: { kind: 1 } } // ok → created
     ]);
@@ -225,7 +227,6 @@ describe('ensureIndexes', () => {
     assert.equal(captured.length, 1);
     assert.equal(captured[0].ctx.method, 'createIndex');
 
-    await dropAllNonId();
     await local.close();
   });
 
@@ -242,11 +243,9 @@ describe('ensureIndexes', () => {
       { dbname: 'test' },
       { onError: (err, ctx) => captured.push({ err, ctx }) }
     );
-    const localItems = local.collection(COLLECTION);
+    const col = local.collection(COLLECTION);
 
-    // Two specs targeting the same key with conflicting options. The first
-    // (unique: true) must win; the second is reported and skipped.
-    const names = await localItems.ensureIndexes([
+    const names = await col.ensureIndexes([
       { key: { handle: 1 }, options: { unique: true } },
       { key: { handle: 1 }, options: { unique: false } }
     ]);
@@ -267,7 +266,6 @@ describe('ensureIndexes', () => {
     assert.equal(captured.length, 1);
     assert.equal(captured[0].ctx.method, 'createIndex');
 
-    await dropAllNonId();
     await local.close();
   });
 
@@ -279,7 +277,6 @@ describe('ensureIndexes', () => {
     ]);
     assert.equal(names.length, 1);
     assert.match(names[0], /city/);
-    await dropAllNonId();
   });
 
   test('hostile getter on an entry is skipped, the rest are processed', async () => {

--- a/test/indexes.js
+++ b/test/indexes.js
@@ -91,6 +91,90 @@ describe('createIndex', () => {
 
     await local.close();
   });
+
+  test('local onError alongside driver options: index created, driver options intact', async () => {
+    const captured = [];
+    const name = await items.createIndex(
+      { brand: 1 },
+      { unique: true, onError: (err, ctx) => captured.push(ctx) }
+    );
+
+    assert.equal(typeof name, 'string');
+    assert.equal(captured.length, 0, 'no error expected on success');
+
+    const native = await mongo.open(COLLECTION);
+    const idx = await native.indexes();
+    const created = idx.find((i) => i.name === name);
+    assert.ok(created);
+    assert.equal(created.unique, true, 'driver options survive the strip');
+  });
+
+  test('options containing only onError still create the index', async () => {
+    const captured = [];
+    const name = await items.createIndex(
+      { lone: 1 },
+      { onError: (err, ctx) => captured.push(ctx) }
+    );
+
+    assert.equal(typeof name, 'string');
+    assert.equal(captured.length, 0);
+    const names = await listIndexNames();
+    assert.ok(names.includes(name));
+  });
+
+  test('local onError: conflict routes locally, client handler stays silent', async () => {
+    let clientCalled = 0;
+    const local = new MongoClient(
+      { dbname: 'test' },
+      {
+        onError: () => {
+          clientCalled = clientCalled + 1;
+        }
+      }
+    );
+    const col = local.collection(COLLECTION);
+
+    await col.createIndex({ color: 1 }, { unique: true });
+
+    const captured = [];
+    const conflicting = await col.createIndex(
+      { color: 1 },
+      { unique: false, onError: (err, ctx) => captured.push(ctx) }
+    );
+
+    assert.equal(conflicting, null);
+    assert.equal(captured.length, 1);
+    assert.equal(captured[0].method, 'createIndex');
+    assert.equal(captured[0].collection, COLLECTION);
+    assert.equal(clientCalled, 0);
+
+    await local.close();
+  });
+
+  test('local onError: invalid spec rejection routes locally', async () => {
+    let clientCalled = 0;
+    const local = new MongoClient(
+      { dbname: 'test' },
+      {
+        onError: () => {
+          clientCalled = clientCalled + 1;
+        }
+      }
+    );
+    const col = local.collection(COLLECTION);
+
+    const captured = [];
+    assert.equal(
+      await col.createIndex(null, {
+        onError: (err, ctx) => captured.push(ctx.method)
+      }),
+      null
+    );
+
+    assert.deepEqual(captured, ['createIndex']);
+    assert.equal(clientCalled, 0);
+    await local.close();
+  });
 });
 
 describe('ensureIndexes', () => {
@@ -196,5 +280,37 @@ describe('ensureIndexes', () => {
     assert.equal(names.length, 1);
     assert.match(names[0], /city/);
     await dropAllNonId();
+  });
+
+  test('per-spec onError routes the conflict locally', async () => {
+    let clientCalled = 0;
+    const local = new MongoClient(
+      { dbname: 'test' },
+      {
+        onError: () => {
+          clientCalled = clientCalled + 1;
+        }
+      }
+    );
+    const col = local.collection(COLLECTION);
+
+    await col.createIndex({ town: 1 }, { unique: true });
+
+    const captured = [];
+    const names = await col.ensureIndexes([
+      {
+        key: { town: 1 },
+        options: { unique: false, onError: (err, ctx) => captured.push(ctx) }
+      },
+      { key: { street: 1 } }
+    ]);
+
+    assert.equal(names.length, 1);
+    assert.match(names[0], /street/);
+    assert.equal(captured.length, 1);
+    assert.equal(captured[0].method, 'createIndex');
+    assert.equal(clientCalled, 0);
+
+    await local.close();
   });
 });

--- a/test/observability.js
+++ b/test/observability.js
@@ -448,3 +448,32 @@ test('async onError: a rejecting client-level handler never surfaces as unhandle
     process.off('unhandledRejection', trap);
   }
 });
+
+test('local onError: validation rejects route to the local handler', async () => {
+  let clientCalled = 0;
+  const mongo = new MongoClient(UNREACHABLE, {
+    onError: () => {
+      clientCalled = clientCalled + 1;
+    }
+  });
+  const col = mongo.collection('users');
+
+  const captured = [];
+  const onError = (err, ctx) => captured.push(`${ctx.method}: ${err.message}`);
+
+  assert.equal(await col.update({}, { $set: { a: 1 } }, { onError }), false);
+  assert.equal(await col.remove(null, { onError }), false);
+  assert.equal(await col.removeById(null, { onError }), false);
+  assert.equal(await col.save('nope', { onError }), null);
+  assert.deepEqual(await col.saveAll('nope', { onError }), []);
+
+  assert.deepEqual(captured, [
+    'update: Empty filter rejected',
+    'remove: Empty filter rejected',
+    'removeById: Invalid id rejected',
+    'save: Invalid document rejected',
+    'saveAll: Invalid documents rejected'
+  ]);
+  assert.equal(clientCalled, 0);
+  await mongo.close();
+});

--- a/test/observability.js
+++ b/test/observability.js
@@ -389,6 +389,79 @@ test('local onError: every options-taking method routes to the local handler', a
   await mongo.close();
 });
 
+test('never-throw: hostile getter in the filter collapses update/remove to the empty-filter reject', async () => {
+  const captured = [];
+  const mongo = new MongoClient(UNREACHABLE, {
+    onError: (err, ctx) => captured.push(`${ctx.method}: ${err.message}`)
+  });
+  const col = mongo.collection('users');
+  const hostile = {
+    get name() {
+      throw new Error('hostile filter getter');
+    }
+  };
+
+  assert.equal(await col.update(hostile, { $set: { a: 1 } }), false);
+  assert.equal(await col.remove(hostile), false);
+  assert.deepEqual(captured, [
+    'update: Empty filter rejected',
+    'remove: Empty filter rejected'
+  ]);
+  await mongo.close();
+});
+
+test('never-throw: revoked Proxy input collapses to the empty default', async () => {
+  const mongo = new MongoClient(UNREACHABLE, { silent: true });
+  const col = mongo.collection('users');
+  const { proxy, revoke } = Proxy.revocable({}, {});
+  revoke();
+
+  assert.deepEqual(await col.saveAll(proxy), []);
+  assert.equal(await col.findById(proxy), null);
+  assert.equal(await col.removeById(proxy), false);
+  assert.equal(await col.createIndex(proxy), null);
+  assert.equal(await col.update(proxy, { $set: { a: 1 } }), false);
+  assert.equal(await col.remove(proxy), false);
+  await mongo.close();
+});
+
+test('never-throw: hostile document getter in saveAll collapses to []', async () => {
+  const captured = [];
+  const mongo = new MongoClient(UNREACHABLE, { silent: true });
+  const col = mongo.collection('users');
+
+  const result = await col.saveAll(
+    [
+      {
+        get a() {
+          throw new Error('hostile doc getter');
+        }
+      }
+    ],
+    { onError: (err, ctx) => captured.push(ctx.method) }
+  );
+
+  assert.deepEqual(result, []);
+  assert.deepEqual(captured, ['saveAll']);
+  await mongo.close();
+});
+
+test('never-throw: hostile getter in an ensureIndexes entry skips the entry', async () => {
+  const mongo = new MongoClient(UNREACHABLE, { silent: true });
+  const col = mongo.collection('users');
+
+  const result = await col.ensureIndexes([
+    {
+      get key() {
+        throw new Error('hostile key getter');
+      }
+    }
+  ]);
+
+  assert.deepEqual(result, []);
+  await mongo.close();
+});
+
 test('async onError: a rejecting local handler never surfaces as unhandledRejection', async () => {
   const leaked = [];
   const trap = (reason) => leaked.push(reason);

--- a/test/observability.js
+++ b/test/observability.js
@@ -192,6 +192,24 @@ test('broken console.error: every public method returns its empty default', asyn
   await mongo.close();
 });
 
+test('throwing onError: find still returns [] without throwing', async () => {
+  const mongo = new MongoClient(UNREACHABLE, {
+    onError: () => {
+      throw new Error('onError hostile');
+    }
+  });
+  let threw = null;
+  let result;
+  try {
+    result = await mongo.collection('users').find({});
+  } catch (err) {
+    threw = err;
+  }
+  assert.equal(threw, null, 'fail-silent contract violated');
+  assert.deepEqual(result, []);
+  await mongo.close();
+});
+
 test('onError: receives ctx with method/collection/query', async () => {
   const captured = [];
   const mongo = new MongoClient(UNREACHABLE, {
@@ -204,4 +222,229 @@ test('onError: receives ctx with method/collection/query', async () => {
   assert.deepEqual(captured[0].query, { name: 'Alexey' });
 
   await mongo.close();
+});
+
+test('local onError: takes ownership — client onError and console.error stay silent', async (t) => {
+  const consoleCalls = [];
+  t.mock.method(console, 'error', (...args) => consoleCalls.push(args));
+
+  let clientCalled = 0;
+  const captured = [];
+  const mongo = new MongoClient(UNREACHABLE, {
+    onError: () => {
+      clientCalled = clientCalled + 1;
+    }
+  });
+
+  const result = await mongo
+    .collection('users')
+    .find(
+      { name: 'x' },
+      { onError: (err, ctx) => captured.push({ err, ctx }) }
+    );
+
+  assert.deepEqual(result, []);
+  assert.equal(captured.length, 1);
+  assert.equal(captured[0].ctx.method, 'find');
+  assert.equal(captured[0].ctx.collection, 'users');
+  assert.deepEqual(captured[0].ctx.query, { name: 'x' });
+  assert.ok(captured[0].err instanceof Error);
+  assert.equal(clientCalled, 0, 'client onError must stay silent');
+  assert.equal(consoleCalls.length, 0, 'console.error must stay silent');
+
+  await mongo.close();
+});
+
+test('local onError: silent client does not suppress it', async () => {
+  const captured = [];
+  const mongo = new MongoClient(UNREACHABLE, { silent: true });
+
+  await mongo
+    .collection('users')
+    .find({}, { onError: (err) => captured.push(err) });
+
+  assert.equal(captured.length, 1);
+  await mongo.close();
+});
+
+test('local onError: throwing handler does not break the call or fall back to the client', async () => {
+  let clientCalled = 0;
+  const mongo = new MongoClient(UNREACHABLE, {
+    onError: () => {
+      clientCalled = clientCalled + 1;
+    }
+  });
+  let threw = null;
+  let result;
+  try {
+    result = await mongo.collection('users').find(
+      {},
+      {
+        onError: () => {
+          throw new Error('local handler hostile');
+        }
+      }
+    );
+  } catch (err) {
+    threw = err;
+  }
+  assert.equal(threw, null, 'fail-silent contract violated');
+  assert.deepEqual(result, []);
+  assert.equal(
+    clientCalled,
+    0,
+    'ownership retained even when the local handler throws'
+  );
+  await mongo.close();
+});
+
+test('local onError: non-function value falls back to the client handler', async () => {
+  let clientCalled = 0;
+  const mongo = new MongoClient(UNREACHABLE, {
+    onError: () => {
+      clientCalled = clientCalled + 1;
+    }
+  });
+
+  const result = await mongo.collection('users').find({}, { onError: 'log' });
+
+  assert.deepEqual(result, []);
+  assert.equal(clientCalled, 1);
+  await mongo.close();
+});
+
+test('local onError: hostile getter does not break the call', async () => {
+  const mongo = new MongoClient(UNREACHABLE, { silent: true });
+  const hostile = {};
+  Object.defineProperty(hostile, 'onError', {
+    get() {
+      throw new Error('hostile getter');
+    }
+  });
+
+  // Catch path: the getter fires while reporting a swallowed driver error.
+  let threw = null;
+  let result;
+  try {
+    result = await mongo.collection('users').find({}, hostile);
+  } catch (err) {
+    threw = err;
+  }
+  assert.equal(threw, null, 'fail-silent contract violated');
+  assert.deepEqual(result, []);
+
+  // Validation-reject path: the getter fires before any try block.
+  let blocked;
+  try {
+    blocked = await mongo
+      .collection('users')
+      .update({}, { $set: { a: 1 } }, hostile);
+  } catch (err) {
+    threw = err;
+  }
+  assert.equal(threw, null, 'fail-silent contract violated');
+  assert.equal(blocked, false);
+
+  await mongo.close();
+});
+
+test('local onError: every options-taking method routes to the local handler', async () => {
+  let clientCalled = 0;
+  const mongo = new MongoClient(UNREACHABLE, {
+    onError: () => {
+      clientCalled = clientCalled + 1;
+    }
+  });
+  const col = mongo.collection('users');
+
+  const survey = {};
+  async function run(label, fn) {
+    const local = [];
+    await fn((err, ctx) => local.push({ err, ctx }));
+    survey[label] = local.length >= 1 && local[0].ctx.method === label;
+  }
+
+  await run('find', (onError) => col.find({}, { onError }));
+  await run('findOne', (onError) => col.findOne({}, { onError }));
+  await run('exists', (onError) => col.exists({}, { onError }));
+  await run('count', (onError) => col.count({ name: 'x' }, { onError }));
+  await run('distinct', (onError) => col.distinct('x', {}, { onError }));
+  await run('save', (onError) => col.save({ a: 1 }, { onError }));
+  await run('saveAll', (onError) => col.saveAll([{ a: 1 }], { onError }));
+  await run('update', (onError) =>
+    col.update({ a: 1 }, { $set: { b: 1 } }, { onError })
+  );
+  await run('remove', (onError) => col.remove({ a: 1 }, { onError }));
+  await run('removeById', (onError) =>
+    col.removeById('507f1f77bcf86cd799439011', { onError })
+  );
+
+  const missed = Object.entries(survey).filter(([, ok]) => !ok);
+  assert.equal(
+    missed.length,
+    0,
+    `methods not routing locally: ${missed.map(([k]) => k).join(', ')}`
+  );
+  assert.equal(clientCalled, 0, 'client onError must stay silent');
+  await mongo.close();
+});
+
+test('async onError: a rejecting local handler never surfaces as unhandledRejection', async () => {
+  const leaked = [];
+  const trap = (reason) => leaked.push(reason);
+  process.on('unhandledRejection', trap);
+
+  try {
+    const mongo = new MongoClient(UNREACHABLE, { silent: true });
+    const result = await mongo.collection('users').find(
+      {},
+      {
+        onError: async () => {
+          throw new Error('async local reporter boom');
+        }
+      }
+    );
+    assert.deepEqual(result, []);
+
+    // Let the rejected handler promise surface if it was going to.
+    await new Promise((resolve) => {
+      setImmediate(resolve);
+    });
+    await new Promise((resolve) => {
+      setImmediate(resolve);
+    });
+    assert.deepEqual(leaked, []);
+
+    await mongo.close();
+  } finally {
+    process.off('unhandledRejection', trap);
+  }
+});
+
+test('async onError: a rejecting client-level handler never surfaces as unhandledRejection', async () => {
+  const leaked = [];
+  const trap = (reason) => leaked.push(reason);
+  process.on('unhandledRejection', trap);
+
+  try {
+    const mongo = new MongoClient(UNREACHABLE, {
+      onError: async () => {
+        throw new Error('async client reporter boom');
+      }
+    });
+    const result = await mongo.collection('users').find({});
+    assert.deepEqual(result, []);
+
+    await new Promise((resolve) => {
+      setImmediate(resolve);
+    });
+    await new Promise((resolve) => {
+      setImmediate(resolve);
+    });
+    assert.deepEqual(leaked, []);
+
+    await mongo.close();
+  } finally {
+    process.off('unhandledRejection', trap);
+  }
 });


### PR DESCRIPTION
Extends the v6.1 fail-silent contract with per-operation observability and deadlines, makes the `is.*` guards total against adversarial input, and closes two cursor and scan failure modes.

### New API options

| Addition | Where | Notes |
| --- | --- | --- |
| `options.onError(err, ctx)` | every method taking `options` | Per-op reporter. Takes **ownership** for that call: bypasses the client hook and is **not** muted by `silent`. Async rejections defused, sync throws swallowed. |
| `options.timeout: ms` | every async method except `findById` | `AbortSignal.timeout` composed with a caller `signal` via `AbortSignal.any`; aborts when either fires. |
| `options.batchSize` | `find`, `findOne` (ignored), `each` | Forwarded to the driver. Matters for `each()` over large docs. |

`ensureIndexes` exposes `onError`, `signal` and `timeout` per entry inside each spec's `options`; `onError` and `timeout` are stripped before the driver, the resolved signal is forwarded.

### Hardening (against hostile / unvalidated input)

- `findById` and `removeById` reject nullish and **plain-object** ids before the driver — `{$ne: null}` smuggled from request input would otherwise match or delete an arbitrary document.
- `save` and `saveAll` reject non-object and non-array input.
- `is.*` guards are now total: `Array.isArray`/`getPrototypeOf` wrapped in try/catch, so throwing getters and revoked Proxies cannot escape a public method.
- `fields: [...]` **fails closed** — built on a null-proto object, non-string entries dropped, collapses to `{_id: 1}` when nothing usable remains (`[]`, `['__proto__']`, `[42]`). User input can no longer disable a field whitelist.
- dbname is `encodeURIComponent`-encoded when building the connection URL.

### Reliability

- `each()` reclaims cursors of iterators abandoned without `break`, `return` and `await using` via a `FinalizationRegistry` — the driver otherwise pins unfinished cursors until `client.close()`. Iterator held weakly, state strongly; a clean `finally` unregisters. Tests run under `--expose-gc` to exercise the path.
- `saveAll` resolves to the successfully inserted subset on partial failure (unordered `insertMany`), `[]` only when nothing landed.

### Behavior changes

- Empty-filter check moved from key-count to **value** presence: `is.filter` now treats `{a: undefined}` as empty, so `update`/`remove` reject it.
- `fields: []` previously yielded no projection (all fields); now `{_id: 1}`.
- `findById` and `removeById` previously passed nullish and object ids through; now rejected.
- `count()` no longer falls back on arbitrary `countDocuments` errors.
