### PR TITLE
v6.3.0: Hardened count()/save()/saveAll(), fixed close() reconnect, documented the trust boundary

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -43,8 +43,8 @@ export class MongoClient {
         throw new Error('The db name must be configured (server.dbname)');
       }
 
-      const host = server.host || DEFAULT_HOST;
-      const port = server.port || DEFAULT_PORT;
+      const host = encodeURIComponent(server.host || DEFAULT_HOST);
+      const port = encodeURIComponent(server.port || DEFAULT_PORT);
 
       this.url = `mongodb://${host}:${port}/${encodeURIComponent(server.dbname)}`;
     }

--- a/lib/client.js
+++ b/lib/client.js
@@ -136,13 +136,17 @@ export class MongoClient {
 
   /**
    * Close the underlying connection and clear cached state. Safe to call
-   * multiple times. Once this settles, the client is permanently closed: a
-   * later operation does not silently reopen a new pool — it collapses to its
-   * empty default instead, same as any other reported error.
+   * multiple times. The client is marked closed synchronously, before any
+   * teardown I/O happens: a later — or even a concurrently-racing — `open()`
+   * call never gets a fresh pool that would outlive this call and go unclosed.
+   * It collapses to its empty default instead, same as any other reported
+   * error.
    *
    * @returns {Promise<void>}
    */
   async close() {
+    this._closed = true;
+
     const previous = this._closing;
 
     const current = (async () => {
@@ -164,8 +168,6 @@ export class MongoClient {
           this.emit(err, { method: 'close' });
         }
       }
-
-      this._closed = true;
     })();
 
     this._closing = current;

--- a/lib/client.js
+++ b/lib/client.js
@@ -6,6 +6,16 @@ import { is } from './utils.js';
 const DEFAULT_HOST = '127.0.0.1';
 const DEFAULT_PORT = '27017';
 
+// A bracketed IPv6 literal (e.g. `[::1]`) must keep its brackets verbatim in
+// the URI authority - percent-encoding them produces an invalid host. Only
+// hex digits, colons, and dots (for IPv4-mapped forms) are allowed inside the
+// brackets, so this can't be abused to smuggle unencoded URL structure.
+const IPV6_LITERAL = /^\[[0-9a-fA-F:.]+\]$/;
+
+function encodeHost(host) {
+  return IPV6_LITERAL.test(host) ? host : encodeURIComponent(host);
+}
+
 /**
  * Lazy, fail-silent MongoDB client wrapper.
  *
@@ -43,7 +53,7 @@ export class MongoClient {
         throw new Error('The db name must be configured (server.dbname)');
       }
 
-      const host = encodeURIComponent(server.host || DEFAULT_HOST);
+      const host = encodeHost(server.host || DEFAULT_HOST);
       const port = encodeURIComponent(server.port || DEFAULT_PORT);
 
       this.url = `mongodb://${host}:${port}/${encodeURIComponent(server.dbname)}`;

--- a/lib/client.js
+++ b/lib/client.js
@@ -58,6 +58,7 @@ export class MongoClient {
     this._connecting = null;
     this._cols = null;
     this._closing = null;
+    this._closed = false;
   }
 
   /**
@@ -72,12 +73,19 @@ export class MongoClient {
 
   /**
    * Resolve to a native driver collection, opening the connection if needed.
-   * Concurrent first calls share a single connect promise.
+   * Concurrent first calls share a single connect promise. Throws once the
+   * client has been closed via `close()` — it does not silently reopen a new
+   * pool for a later operation; each `Collection` method catches this and
+   * collapses to its own empty default.
    *
    * @param {string} name
    * @returns {Promise<import('mongodb').Collection>}
    */
   async open(name) {
+    if (this._closed) {
+      throw new Error('Client is closed');
+    }
+
     if (!this._connecting) {
       const client = new NativeMongoClient(this.url, this.driverOptions);
       this.client = client;
@@ -128,7 +136,9 @@ export class MongoClient {
 
   /**
    * Close the underlying connection and clear cached state. Safe to call
-   * multiple times.
+   * multiple times. Once this settles, the client is permanently closed: a
+   * later operation does not silently reopen a new pool — it collapses to its
+   * empty default instead, same as any other reported error.
    *
    * @returns {Promise<void>}
    */
@@ -141,20 +151,21 @@ export class MongoClient {
       }
 
       const { client } = this;
-      if (!client) {
-        return;
+
+      if (client) {
+        this.client = null;
+        this.db = null;
+        this._connecting = null;
+        this._cols = null;
+
+        try {
+          await client.close();
+        } catch (err) {
+          this.emit(err, { method: 'close' });
+        }
       }
 
-      this.client = null;
-      this.db = null;
-      this._connecting = null;
-      this._cols = null;
-
-      try {
-        await client.close();
-      } catch (err) {
-        this.emit(err, { method: 'close' });
-      }
+      this._closed = true;
     })();
 
     this._closing = current;

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -160,9 +160,15 @@ export class Collection {
    * shutdown.
    *
    * Non-empty filters use `countDocuments`, which rejects operators disallowed
-   * in `$match` (`$where`, `$near`). Only that error class — `BadValue` or a
-   * `Location*` uassert — triggers the fallback: streaming `_id`s through a
-   * cursor and counting in place, one batch at a time. Network, timeout, abort,
+   * in `$match` (`$where`, `$near`). That error class — `BadValue` or a
+   * `Location*` uassert — triggers a fallback: streaming `_id`s through a
+   * cursor and counting in place, one batch at a time — except when the query
+   * contains `$where` (at any depth inside `$and`/`$or`/`$nor`): `find()` would
+   * execute that JS against every scanned document, turning a rejected query
+   * into server-side code execution, so those collapse to 0 like any other
+   * error instead. The fallback itself is reported via `onError`/the client
+   * hook before it runs — even though it isn't a failure — since a full
+   * collection scan has a real cost worth surfacing. Network, timeout, abort,
    * and auth errors are not retried via the fallback (a full scan is the worst
    * response to a struggling server); they collapse to 0.
    *
@@ -186,9 +192,18 @@ export class Collection {
         const unsupported =
           err?.name === 'MongoServerError' &&
           (err.code === 2 || String(err.codeName).startsWith('Location'));
-        if (!unsupported) {
+        if (!unsupported || hasWhere(prepared)) {
           throw err;
         }
+
+        report(
+          this.client,
+          options,
+          new Error(
+            'count() fallback: countDocuments rejected the query, scanning the full collection instead'
+          ),
+          { method: 'count', collection: this.name, query }
+        );
 
         const cursor = col.find(
           prepared,
@@ -754,6 +769,33 @@ function withSignal(driverOpts, options) {
 
 function attach(driverOpts, signal) {
   return signal ? { ...driverOpts, signal } : driverOpts;
+}
+
+const LOGICAL_OPERATORS = ['$and', '$or', '$nor'];
+const MAX_WHERE_DEPTH = 8;
+
+// Detects `$where` anywhere a hostile filter could hide it - MongoDB validates
+// `$where` recursively through $and/$or/$nor, not just at the top level, so a
+// flat/one-level check isn't enough. Depth-capped rather than unbounded so a
+// hostile or self-referential filter (prepare() only shallow-clones) can't
+// recurse forever.
+function hasWhere(value, depth = 0) {
+  if (depth > MAX_WHERE_DEPTH || !is.obj(value)) {
+    return false;
+  }
+
+  if (Object.hasOwn(value, '$where')) {
+    return true;
+  }
+
+  for (const op of LOGICAL_OPERATORS) {
+    const clause = value[op];
+    if (is.arr(clause) && clause.some((c) => hasWhere(c, depth + 1))) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 function projectionOf(options) {

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -49,19 +49,20 @@ export class Collection {
   }
 
   /**
-   * Iterate matching documents lazily without materializing an array. The
-   * returned object exposes only `Symbol.asyncIterator` and
-   * `Symbol.asyncDispose`, composing with `for await` and `await using`.
+   * Iterate matching documents lazily without materializing an array.
    *
-   * The cursor opens on first iteration and closes when iteration ends —
-   * naturally, by `break`, or on `await using` scope exit. Errors collapse the
-   * loop to an early end and route through `options.onError` or `client.emit`;
-   * no exception escapes the `for await`.
-   *
-   * The value is a factory: each `[Symbol.asyncIterator]()` call opens its own
-   * cursor, so it can be iterated repeatedly, sequentially or in parallel. An
-   * abandoned iterator releases its cursor only when GC collects it; prefer
-   * explicit lifetime management for unbounded queries.
+   * - Exposes only `Symbol.asyncIterator` and `Symbol.asyncDispose` — composes
+   *   with `for await` and `await using`.
+   * - The cursor opens on first iteration and closes when iteration ends:
+   *   naturally, by `break`, or on `await using` scope exit.
+   * - Errors collapse the loop to an early end and route through
+   *   `options.onError` or `client.emit`; no exception escapes the `for
+   *   await`.
+   * - The returned value is a factory: each `[Symbol.asyncIterator]()` call opens
+   *   its own cursor, so it can be iterated repeatedly, sequentially or in
+   *   parallel.
+   * - An abandoned iterator releases its cursor only when GC collects it; prefer
+   *   explicit lifetime management for unbounded queries.
    *
    * @param {object} [query]
    * @param {object} [options] - { limit?, skip?, sort?, fields?, projection?,
@@ -155,22 +156,20 @@ export class Collection {
   /**
    * Count documents matching the query.
    *
-   * An empty/missing query short-circuits to `estimatedDocumentCount`: cached
-   * collection size, no scan; may drift on sharded clusters or after an unclean
-   * shutdown.
-   *
-   * Non-empty filters use `countDocuments`, which rejects operators disallowed
-   * in `$match` (`$where`, `$near`). That error class — `BadValue` or a
-   * `Location*` uassert — triggers a fallback: streaming `_id`s through a
-   * cursor and counting in place, one batch at a time — except when the query
-   * contains `$where` (at any depth inside `$and`/`$or`/`$nor`): `find()` would
-   * execute that JS against every scanned document, turning a rejected query
-   * into server-side code execution, so those collapse to 0 like any other
-   * error instead. The fallback itself is reported via `onError`/the client
-   * hook before it runs — even though it isn't a failure — since a full
-   * collection scan has a real cost worth surfacing. Network, timeout, abort,
-   * and auth errors are not retried via the fallback (a full scan is the worst
-   * response to a struggling server); they collapse to 0.
+   * - Empty/missing query: short-circuits to `estimatedDocumentCount` (cached
+   *   collection size, no scan; may drift on sharded clusters or after an
+   *   unclean shutdown).
+   * - Non-empty filter: uses `countDocuments`, which rejects operators disallowed
+   *   in `$match` (`$where`, `$near`) with a `BadValue`/`Location*` error.
+   * - That rejection falls back to streaming `_id`s through a cursor and counting
+   *   in place — except when the query contains `$where` (at any depth inside
+   *   `$and`/`$or`/`$nor`): `find()` would execute that JS against every
+   *   scanned document, so those collapse to `0` instead of falling back.
+   * - The fallback is reported via `onError`/the client hook before it runs (a
+   *   full collection scan has a real cost worth surfacing).
+   * - Network, timeout, abort, and auth errors are not retried via the fallback
+   *   (a full scan is the worst response to a struggling server); they collapse
+   *   to `0`.
    *
    * @param {object} [query]
    * @param {object} [options] - { signal?, timeout?, onError? }
@@ -418,7 +417,7 @@ export class Collection {
    * 'related' }]`). No other driver options are exposed.
    *
    * @param {object} query
-   * @param {object} update - Mongo update operators (e.g. {$set: {...}})
+   * @param {object} update - E.g. {$set: {...}}
    * @param {object} [options] - { arrayFilters?, signal?, timeout?, onError? }
    * @returns {Promise<boolean>} True if at least one document was modified
    */

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -271,6 +271,10 @@ export class Collection {
    * coerced to ObjectId). Documents that need a literal `id` data field should
    * nest it or use a different name.
    *
+   * A plain-object `_id` is rejected (reported, resolved to null) — same
+   * operator-smuggling guard as `findById`/`removeById`, applied here for
+   * consistency before it ever reaches `replaceOne`'s filter.
+   *
    * @param {object} doc
    * @param {object} [options] - { signal?, timeout?, onError? }
    * @returns {Promise<object | null>}
@@ -288,6 +292,16 @@ export class Collection {
     try {
       const col = await this.client.open(this.name);
       const prepared = prepare(doc);
+
+      if (is.obj(prepared._id)) {
+        report(this.client, options, new Error('Invalid _id rejected'), {
+          method: 'save',
+          collection: this.name,
+          query: { _id: prepared._id }
+        });
+
+        return null;
+      }
 
       if (prepared._id != null) {
         const result = await col.replaceOne(
@@ -327,7 +341,8 @@ export class Collection {
    *
    * Non-array input is rejected (reported, resolved to []); non-object entries
    * are silently dropped. Each document gets the same `id` → `_id` alias
-   * normalization as `save`.
+   * normalization as `save`, including the same plain-object-`_id` guard — a
+   * matching entry is dropped and reported rather than silently skipped.
    *
    * @param {object[]} docs
    * @param {object} [options] - { signal?, timeout?, onError? }
@@ -347,9 +362,23 @@ export class Collection {
 
     try {
       for (const doc of docs) {
-        if (is.obj(doc)) {
-          prepared.push(prepare(doc));
+        if (!is.obj(doc)) {
+          continue;
         }
+
+        const ready = prepare(doc);
+
+        if (is.obj(ready._id)) {
+          report(this.client, options, new Error('Invalid _id rejected'), {
+            method: 'saveAll',
+            collection: this.name,
+            query: { _id: ready._id }
+          });
+
+          continue;
+        }
+
+        prepared.push(ready);
       }
 
       if (prepared.length === 0) {

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -803,26 +803,35 @@ function attach(driverOpts, signal) {
 }
 
 const LOGICAL_OPERATORS = ['$and', '$or', '$nor'];
-const MAX_WHERE_DEPTH = 8;
 
 // Detects `$where` anywhere a hostile filter could hide it - MongoDB validates
-// `$where` recursively through $and/$or/$nor, not just at the top level, so a
-// flat/one-level check isn't enough. Depth-capped rather than unbounded so a
-// hostile or self-referential filter (prepare() only shallow-clones) can't
-// recurse forever.
-function hasWhere(value, depth = 0) {
-  if (depth > MAX_WHERE_DEPTH || !is.obj(value)) {
-    return false;
-  }
+// `$where` recursively through $and/$or/$nor, not just at the top level, at
+// any depth. Iterative with a `seen` set rather than recursive with a depth
+// cap: a depth cap would let a filter nested deep enough slip through as
+// "safe" and still reach the vulnerable scan fallback. `seen` guards against
+// a self-referential filter (prepare() only shallow-clones) looping forever,
+// without limiting how deep a genuinely acyclic filter can be checked.
+function hasWhere(root) {
+  const stack = [root];
+  const seen = new Set();
 
-  if (Object.hasOwn(value, '$where')) {
-    return true;
-  }
+  while (stack.length > 0) {
+    const value = stack.pop();
 
-  for (const op of LOGICAL_OPERATORS) {
-    const clause = value[op];
-    if (is.arr(clause) && clause.some((c) => hasWhere(c, depth + 1))) {
+    if (!is.obj(value) || seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+
+    if (Object.hasOwn(value, '$where')) {
       return true;
+    }
+
+    for (const op of LOGICAL_OPERATORS) {
+      const clause = value[op];
+      if (is.arr(clause)) {
+        stack.push(...clause);
+      }
     }
   }
 

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -592,6 +592,8 @@ export class Collection {
     for (const item of specs) {
       let name = null;
       try {
+        // Guards hostile getters on item.key/item.options, not a throw from
+        // createIndex - that's separately fail-silent by its own contract.
         if (is.obj(item) && item.key != null) {
           // oxlint-disable-next-line no-await-in-loop
           name = await this.createIndex(item.key, item.options);

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -32,22 +32,18 @@ const SCALAR_OPERATORS = ['$eq', '$ne', '$gt', '$gte', '$lt', '$lte'];
  * Normalize a query object before passing it to the driver. Returns a NEW
  * object — input is never mutated.
  *
- * Behavior:
- *
  * - Null / undefined → {}
  * - Non-object → returned as-is
  * - { id: x } → { _id: prepareId(x) }
  * - { _id: 'hex' } → { _id: ObjectId('hex') }
- * - { _id: { $in: [...] } } → each element coerced via prepareId
- * - { _id: { $nin: [...] } } → each element coerced via prepareId
+ * - { _id: { $in/$nin: [...] } } → each element coerced via prepareId
  * - { _id: { $eq/$ne/$gt/$gte/$lt/$lte: 'hex' } } → scalar coerced via prepareId
  * - Any other object passes through cloned
- *
- * `_id: undefined` or `_id: null` are treated as absent: if `id` is also
- * provided it drives the alias rewrite; otherwise the value passes through
- * as-is (no random ObjectId is generated). The legacy `id` field is always
- * removed when `_id` is present (either directly or via alias), so it never
- * leaks into the driver query as a literal field.
+ * - `_id: undefined`/`_id: null` count as absent: `id` drives the alias rewrite
+ *   if present, otherwise the value passes through unchanged (no random
+ *   ObjectId is generated)
+ * - The legacy `id` field is always removed once `_id` is present (directly or
+ *   via alias), so it never leaks into the driver query as a literal field
  *
  * @param {unknown} params
  * @returns {object | unknown} A new object for plain-object/nullish input;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easymongo",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "Thin, opinionated wrapper around the MongoDB Node.js driver with a fail-silent promise API.",
   "keywords": [
     "easymongo",
@@ -32,14 +32,14 @@
     "coverage": "mkdir -p coverage && node --expose-gc --test --experimental-test-coverage --test-coverage-lines=97 --test-coverage-branches=93 --test-coverage-functions=93 --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info test/*.js"
   },
   "dependencies": {
-    "mongodb": "^7.3.0"
+    "mongodb": "^7.4.0"
   },
   "devDependencies": {
     "oxfmt": "^0.57.0",
-    "oxlint": "^1.69.0"
+    "oxlint": "^1.72.0"
   },
   "engines": {
     "node": ">=24.16"
   },
-  "packageManager": "pnpm@11.5.3"
+  "packageManager": "pnpm@11.9.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     dependencies:
       mongodb:
-        specifier: ^7.3.0
+        specifier: ^7.4.0
         version: 7.4.0
     devDependencies:
       oxfmt:
         specifier: ^0.57.0
         version: 0.57.0
       oxlint:
-        specifier: ^1.69.0
+        specifier: ^1.72.0
         version: 1.72.0
 
 packages:

--- a/readme.md
+++ b/readme.md
@@ -48,18 +48,19 @@ The connection opens lazily on the first I/O call. Concurrent first calls share 
 
 This is a thin wrapper, not a sanitizing layer. Read this before pointing it at request input.
 
-- **Filters reach the driver unsanitized on every method** — `find`, `findOne`, `exists`, `count`, `distinct`, `update`, `remove`, and `each()` (easy to miss, since it's the streaming path) all pass the query through as-is.
-- **The update-document is unsanitized too** — `update()`'s 2nd argument applies exactly as given; an untrusted `$set`/`$inc` payload is a mass-assignment vector.
-- **`options.fields`/`projection`/`sort` aren't sanitized either** — the fail-closed array whitelist only blocks a degenerate input (`[]`, `['__proto__']`); `fields: ['password']` is a valid whitelist entry and goes straight through.
+- **Filters reach the driver unsanitized on every method.** `find`, `findOne`, `exists`, `count`, `distinct`, `update`, `remove`, and `each()` (easy to miss, since it's the streaming path) all pass the query through as-is.
+- **The update-document is unsanitized too.** `update()`'s 2nd argument applies exactly as given; an untrusted `$set`/`$inc` payload is a mass-assignment vector.
+- **`options.fields`/`projection`/`sort` aren't sanitized either.** The fail-closed array whitelist only blocks a degenerate input (`[]`, `['__proto__']`); `fields: ['password']` is a valid whitelist entry and goes straight through.
 - **The only guarded surface** is the scalar `_id` slot in `findById`/`removeById`, which reject a plain-object id.
 
-Never pass `req.body`/`req.query` directly as a query, an update-document, or an options object — build and validate it yourself.
+Never pass `req.body`/`req.query` directly as a query, an update-document, or an options object. Build and validate it yourself.
 
-Three more things worth knowing before production:
+Also:
 
-- **Empty and failure look identical** — a `[]`, `null`, or `false` tells you nothing about whether the operation failed. See [Per-operation `onError`](#per-operation-onerror) for the pattern that tells them apart.
-- **A literal `id` field is a footgun** — documents synced from an external API (Stripe, YouTube, anything REST-shaped) often already have their own `id`, and it silently becomes `_id` instead of staying a literal field. See [IDs](#ids) for the mechanics.
-- **Driver errors can carry more than you'd expect** — the default logger never prints `ctx.query`, but the underlying error message can still embed field values (a duplicate-key error, for one). See [Observability](#observability).
+- **Empty and failure look identical.** A `[]`, `null`, or `false` tells you nothing about whether the operation failed. See [Per-operation `onError`](#per-operation-onerror) for the pattern that tells them apart.
+- **A literal `id` field is a footgun.** Documents synced from an external API (Stripe, YouTube, anything REST-shaped) often already have their own `id`, which silently becomes `_id` instead of staying a literal field. See [IDs](#ids) for the mechanics.
+- **A connection string with no db path is a footgun too.** `mongodb://127.0.0.1:27017` (no `/dbname`) is not validated and silently defaults to the driver's `test` database. See [Client](#client).
+- **Driver error messages can carry more than the default logger prints.** `ctx.query` is never printed by the default reporter, but the underlying error message can still embed field values (a duplicate-key error, for one). See [Observability](#observability).
 
 ## Client
 
@@ -76,7 +77,7 @@ new MongoClient(server, options?)
 | `silent`  | `false`         | Suppress all internal error reporting                         |
 | `onError` | `console.error` | `(err, ctx) => void`, `ctx = { method, collection?, query? }` |
 
-`client.collection(name)` returns a `Collection`. `client.close()` releases the connection and is safe to call more than once. Concurrent `close()` calls share one teardown. Once `close()` resolves, the client is permanently closed — a later operation does not reopen a new pool; it collapses to its own empty default and is reported, same as any other swallowed error.
+`client.collection(name)` returns a `Collection`. `client.close()` releases the connection and is safe to call more than once. Concurrent `close()` calls share one teardown. Once `close()` resolves, the client is permanently closed. A later operation does not reopen a new pool; it collapses to its own empty default and is reported, same as any other swallowed error.
 
 `MongoClient` implements `Symbol.asyncDispose`, so it composes with `await using`:
 
@@ -110,11 +111,11 @@ new MongoClient(server, options?)
 
 Every async method except `findById` accepts `options.signal: AbortSignal` and `options.timeout: ms` for cancellation (see [AbortSignal and timeout](#abortsignal-and-timeout)) and a per-operation `options.onError` reporter (see [Observability](#observability)); for `ensureIndexes`, pass them inside each entry's `options`. `oid(value?)` is synchronous: it coerces a valid 24-char hex string to `ObjectId`, mints a fresh one for nullish input, and returns anything else untouched.
 
-`save` inserts when `_id` is absent and replaces via `upsert` when present. Documents passed to `save`/`saveAll` get the same `id` → `_id` alias rewrite as queries — a top-level `id` field never reaches the database as a literal field. A plain-object `_id` (e.g. `{$gt: ''}`, operator smuggling) is rejected and reported, same as `findById`/`removeById` reject a plain-object id. `saveAll` delegates to an unordered `insertMany`; non-object entries are dropped silently, and on partial failure (e.g. one entry hits a duplicate key) it resolves to the successfully inserted subset instead of `[]`. Non-object input to `save` and non-array input to `saveAll` are rejected and reported, like every other validation reject.
+`save` inserts when `_id` is absent and replaces via `upsert` when present. Documents passed to `save`/`saveAll` get the same `id` → `_id` alias rewrite as queries. A top-level `id` field never reaches the database as a literal field. A plain-object `_id` (e.g. `{$gt: ''}`, operator smuggling) is rejected and reported, same as `findById`/`removeById` reject a plain-object id. `saveAll` delegates to an unordered `insertMany`; non-object entries are dropped silently, and on partial failure (e.g. one entry hits a duplicate key) it resolves to the successfully inserted subset instead of `[]`. Non-object input to `save` and non-array input to `saveAll` are rejected and reported, like every other validation reject.
 
 `count({})` short-circuits to `estimatedDocumentCount`, which reads the cached collection size without a full scan. Numbers may be slightly off on sharded collections with orphans or after an unclean shutdown, but the path is roughly two orders of magnitude faster.
 
-`count(query)` with a non-empty filter calls `countDocuments` and falls back to a streamed `find` cursor with `_id`-only projection when the driver rejects the query (operators such as `$where` and `$near` are valid in `find` but not in the aggregation `$match` that `countDocuments` builds) — except for `$where` itself (at any depth inside `$and`/`$or`/`$nor`), which never falls back: re-running it via the cursor would execute that JS against every document, so it collapses to `0` like any other rejected query instead. The remaining fallback streams in batches and is bounded in memory, but it's a real round trip — prefer indexed predicates when possible — and is reported via `onError` before it runs, so the cost is observable.
+`count(query)` with a non-empty filter calls `countDocuments`, falling back to a streamed `find` cursor with `_id`-only projection when the driver rejects the query (operators such as `$where` and `$near` are valid in `find` but not in the aggregation `$match` that `countDocuments` builds). `$where` itself (at any depth inside `$and`/`$or`/`$nor`) never falls back, because re-running it via the cursor would execute that JS against every document, so it collapses to `0` like any other rejected query. The fallback streams in batches, bounded in memory, but is a real round trip; it's reported via `onError` before it runs, so the cost is observable.
 
 ## Read options
 
@@ -133,7 +134,7 @@ await users.find(
 );
 ```
 
-`limit`, `skip`, `sort`, and `batchSize` pass through to the driver (`findOne` takes no `limit` or `batchSize` — it always fetches a single document; `batchSize` bounds how many documents each cursor fetch may buffer, which matters for `each()` over large documents).
+`limit`, `skip`, `sort`, and `batchSize` pass through to the driver (`findOne` takes no `limit` or `batchSize` since it always fetches a single document; `batchSize` bounds how many documents each cursor fetch may buffer, which matters for `each()` over large documents).
 
 Projection accepts three forms:
 
@@ -143,7 +144,7 @@ await users.find({}, { fields: { password: 0 } }); // exclusion map, passed thro
 await users.find({}, { projection: { name: 1 } }); // native driver shape, passed through as-is
 ```
 
-The array form fails closed: it always produces a projection. Non-string entries are ignored, and when nothing usable remains (`[]`, `['__proto__']`, `[42]`) the projection collapses to `{ _id: 1 }` — a user-controlled array cannot silently disable a field whitelist.
+The array form fails closed: it always produces a projection. Non-string entries are ignored, and when nothing usable remains (`[]`, `['__proto__']`, `[42]`) the projection collapses to `{ _id: 1 }`, so a user-controlled array cannot silently disable a field whitelist.
 
 `findById` accepts the array and map forms positionally: `findById(id, ['name'])`.
 
@@ -171,9 +172,9 @@ For long-running iteration, scope the cursor with `await using` so it is closed 
 }
 ```
 
-The returned object is a factory — each `for await` opens its own cursor, so the same `each(...)` value can be iterated multiple times sequentially or in parallel. Abandoning an iterator without `break`/`return`/`await using` delays cursor cleanup until the generator is GC'd or the client is closed; prefer explicit lifetime management for unbounded queries.
+The returned object is a factory: each `for await` opens its own cursor, so the same `each(...)` value can be iterated multiple times sequentially or in parallel. Abandoning an iterator without `break`/`return`/`await using` delays cursor cleanup until the generator is GC'd or the client is closed; prefer explicit lifetime management for unbounded queries.
 
-`each()` exposes only `Symbol.asyncIterator` and `Symbol.asyncDispose`. There is no `close()` method or `cancel()` on the returned object — disposal is the only way to terminate iteration explicitly.
+`each()` exposes only `Symbol.asyncIterator` and `Symbol.asyncDispose`. There is no `close()` method or `cancel()` on the returned object; disposal is the only way to terminate iteration explicitly.
 
 Errors during open or iteration end the loop quietly and report through the local `options.onError` when one was passed, otherwise through the client-level `onError` (or `console.error`), with `ctx.method === 'each'`. Cursor close errors are reported with `ctx.method === 'each.close'`.
 
@@ -193,7 +194,7 @@ await users.ensureIndexes([
 
 `createIndex(spec, options?)` returns the index name, or `null` if the driver rejects the spec or there is a conflict with an existing index.
 
-`ensureIndexes(specs)` processes its input sequentially — when two entries target the same key with different options, the **first one wins**: it succeeds, and the rest collapse to a conflict + `onError` and are skipped. Returns the names of successfully created or already-present indexes.
+`ensureIndexes(specs)` processes its input sequentially. When two entries target the same key with different options, the **first one wins**: it succeeds, the rest collapse to a conflict + `onError`, and are skipped. Returns the names of successfully created or already-present indexes. One exception to every other validation reject being reported: a non-array `specs` argument, or a hostile getter on an entry's `key`/`options`, is skipped without calling `onError`.
 
 ## IDs
 
@@ -214,9 +215,9 @@ await users.find({ _id: { $gt: '4e4e1638c85e808431000003' } }); // scalar compar
 
 Strings that are not valid 24-character hex pass through unchanged, so numeric and UUID `_id` schemes keep working.
 
-`findById`/`removeById` reject `null`, `undefined`, and plain-object ids before the driver sees them (reported as `Invalid id rejected`): an operator object like `{ $ne: null }` smuggled from request input would otherwise match — or delete — an arbitrary document. Use `findOne({ _id: { ... } })` for intentional operator queries.
+`findById`/`removeById` reject `null`, `undefined`, and plain-object ids before the driver sees them (reported as `Invalid id rejected`): an operator object like `{ $ne: null }` smuggled from request input would otherwise match, or delete, an arbitrary document. Use `findOne({ _id: { ... } })` for intentional operator queries.
 
-Apart from this id normalization, query objects are passed to the driver **unsanitized** — see [Trust boundary](#trust-boundary) for the full picture, including the update-document and read `options`.
+Apart from this id normalization, query objects are passed to the driver **unsanitized**; see [Trust boundary](#trust-boundary) for the full picture, including the update-document and read `options`.
 
 ## Observability
 
@@ -230,19 +231,19 @@ new MongoClient(url, { silent: true }); // suppress all internal logging
 new MongoClient(url, { onError: (err, ctx) => console.error(ctx.method, err) }); // custom handler
 ```
 
-`silent: true` mutes the whole client-level channel — including a custom client-level `onError`. A per-operation `options.onError` is the one thing it does not suppress (see below).
+`silent: true` mutes the whole client-level channel, including a custom client-level `onError`. A per-operation `options.onError` is the one thing it does not suppress (see below).
 
 The `ctx` passed to `onError` has the shape `{ method, collection?, query? }`, e.g. `{ method: 'findOne', collection: 'users', query: { email: 'a@b.c' } }`.
 
-Mind what reaches your logs: `ctx.query` is the original query object and may carry PII or secrets, and driver error messages can embed document values too (a duplicate-key `E11000` includes the offending value). The default `console.error` reporter prints only `[easymongo] <collection>.<method> failed:` plus the error — never `ctx.query` — but a custom `onError` owns redaction of everything it forwards.
+Mind what reaches your logs: `ctx.query` is the original query object and may carry PII or secrets, and driver error messages can embed document values too (a duplicate-key `E11000` includes the offending value). The default `console.error` reporter prints only `[easymongo] <collection>.<method> failed:` plus the error, never `ctx.query`, but a custom `onError` owns redaction of everything it forwards.
 
 A throwing `onError` is itself caught and ignored, and a rejected promise from an `async` handler is defused the same way; a broken reporter cannot take down the caller (the rejection is silently dropped, so do your own catching inside async handlers if you care about their failures).
 
 ### Per-operation `onError`
 
-Every method that takes `options` also accepts a local `onError(err, ctx)`. When a function is passed, it takes ownership of the error for that one call: the client-level `onError` and the default `console.error` stay silent, and `silent: true` does not suppress it — an explicitly passed callback is a requested channel, not internal logging.
+Every method that takes `options` also accepts a local `onError(err, ctx)`. When a function is passed, it takes ownership of the error for that one call: the client-level `onError` and the default `console.error` stay silent, and `silent: true` does not suppress it, since an explicitly passed callback is a requested channel, not internal logging.
 
-This is the escape hatch for callers that need to know whether _this particular_ operation failed — no shared state, no races between parallel operations, works with a client configured elsewhere:
+This lets a caller check whether _this particular_ call failed, without racing against other concurrent calls to a shared client-level handler:
 
 ```js
 let failure = null;
@@ -266,11 +267,11 @@ if (failure) {
 }
 ```
 
-`findById` has no options slot — use `findOne({ _id: id }, { onError })`. For `ensureIndexes`, pass `onError` inside each spec's `options`. A throwing local handler is caught and ignored, same as the client-level one. One caveat for `each()`: the local handler should not capture its own iterator, or an abandoned iterator can never be garbage-collected and its cursor stays pinned until the client is closed.
+`findById` has no options slot, so use `findOne({ _id: id }, { onError })`. For `ensureIndexes`, pass `onError` inside each spec's `options`. A throwing local handler is caught and ignored, same as the client-level one. One caveat for `each()`: the local handler should not capture its own iterator, or an abandoned iterator can never be garbage-collected and its cursor stays pinned until the client is closed.
 
 ## Empty filter protection
 
-`update(query, $update)` and `remove(query)` reject empty filters. `null`, `undefined`, and `{}` short-circuit to `false` without touching the driver. The rejection is reported through `onError` (or `console.error`) with `{ method, collection, query }` so it stays visible.
+`update(query, $update)` and `remove(query)` reject empty filters. `null`, `undefined`, `{}`, and a filter whose values are all `undefined` (e.g. `{field: undefined}`) short-circuit to `false` without touching the driver. The rejection is reported through `onError` (or `console.error`) with `{ method, collection, query }` so it stays visible.
 
 ```js
 await users.update(maybeMissing, { $set: { url: 'x' } }); // false, nothing rewritten
@@ -305,7 +306,7 @@ const docs = await users.find({}, { signal: ctrl.signal });
 // [] if the operation was aborted before completion
 ```
 
-`options.timeout: ms` arms a per-operation deadline (`AbortSignal.timeout` under the hood) and composes with a caller signal via `AbortSignal.any` — the operation aborts when either fires. Non-positive and non-numeric values are ignored.
+`options.timeout: ms` arms a per-operation deadline (`AbortSignal.timeout` under the hood) and composes with a caller signal via `AbortSignal.any`, aborting when either fires. Non-positive and non-numeric values are ignored.
 
 ```js
 const docs = await users.find({}, { timeout: 500, signal: ctrl.signal });
@@ -314,7 +315,7 @@ const docs = await users.find({}, { timeout: 500, signal: ctrl.signal });
 
 Aborting mid-iteration of `each()` ends the loop quietly and reports through `onError`.
 
-`update({}, ..., {signal: aborted})` and `remove({}, {signal: aborted})` hit the empty-filter guard first, so the abort is invisible in `onError` for that one combination — pass a non-empty filter when both apply.
+`update({}, ..., {signal: aborted})` and `remove({}, {signal: aborted})` hit the empty-filter guard first, so the abort is invisible in `onError` for that one combination; pass a non-empty filter when both apply.
 
 ## Author
 

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,23 @@ await mongo.close();
 
 The connection opens lazily on the first I/O call. Concurrent first calls share a single connect. Call `close()` when done.
 
+## Trust boundary
+
+This is a thin wrapper, not a sanitizing layer. Read this before pointing it at request input.
+
+- **Filters reach the driver unsanitized on every method** — `find`, `findOne`, `exists`, `count`, `distinct`, `update`, `remove`, and `each()` (easy to miss, since it's the streaming path) all pass the query through as-is.
+- **The update-document is unsanitized too** — `update()`'s 2nd argument applies exactly as given; an untrusted `$set`/`$inc` payload is a mass-assignment vector.
+- **`options.fields`/`projection`/`sort` aren't sanitized either** — the fail-closed array whitelist only blocks a degenerate input (`[]`, `['__proto__']`); `fields: ['password']` is a valid whitelist entry and goes straight through.
+- **The only guarded surface** is the scalar `_id` slot in `findById`/`removeById`, which reject a plain-object id.
+
+Never pass `req.body`/`req.query` directly as a query, an update-document, or an options object — build and validate it yourself.
+
+Three more things worth knowing before production:
+
+- **Empty and failure look identical** — a `[]`, `null`, or `false` tells you nothing about whether the operation failed. See [Per-operation `onError`](#per-operation-onerror) for the pattern that tells them apart.
+- **A literal `id` field is a footgun** — documents synced from an external API (Stripe, YouTube, anything REST-shaped) often already have their own `id`, and it silently becomes `_id` instead of staying a literal field. See [IDs](#ids) for the mechanics.
+- **Driver errors can carry more than you'd expect** — the default logger never prints `ctx.query`, but the underlying error message can still embed field values (a duplicate-key error, for one). See [Observability](#observability).
+
 ## Client
 
 ```js
@@ -59,7 +76,7 @@ new MongoClient(server, options?)
 | `silent`  | `false`         | Suppress all internal error reporting                         |
 | `onError` | `console.error` | `(err, ctx) => void`, `ctx = { method, collection?, query? }` |
 
-`client.collection(name)` returns a `Collection`. `client.close()` releases the connection and is safe to call more than once. Concurrent `close()` calls share one teardown.
+`client.collection(name)` returns a `Collection`. `client.close()` releases the connection and is safe to call more than once. Concurrent `close()` calls share one teardown. Once `close()` resolves, the client is permanently closed — a later operation does not reopen a new pool; it collapses to its own empty default and is reported, same as any other swallowed error.
 
 `MongoClient` implements `Symbol.asyncDispose`, so it composes with `await using`:
 
@@ -93,11 +110,11 @@ new MongoClient(server, options?)
 
 Every async method except `findById` accepts `options.signal: AbortSignal` and `options.timeout: ms` for cancellation (see [AbortSignal and timeout](#abortsignal-and-timeout)) and a per-operation `options.onError` reporter (see [Observability](#observability)); for `ensureIndexes`, pass them inside each entry's `options`. `oid(value?)` is synchronous: it coerces a valid 24-char hex string to `ObjectId`, mints a fresh one for nullish input, and returns anything else untouched.
 
-`save` inserts when `_id` is absent and replaces via `upsert` when present. Documents passed to `save`/`saveAll` get the same `id` → `_id` alias rewrite as queries — a top-level `id` field never reaches the database as a literal field. `saveAll` delegates to an unordered `insertMany`; non-object entries are dropped silently, and on partial failure (e.g. one entry hits a duplicate key) it resolves to the successfully inserted subset instead of `[]`. Non-object input to `save` and non-array input to `saveAll` are rejected and reported, like every other validation reject.
+`save` inserts when `_id` is absent and replaces via `upsert` when present. Documents passed to `save`/`saveAll` get the same `id` → `_id` alias rewrite as queries — a top-level `id` field never reaches the database as a literal field. A plain-object `_id` (e.g. `{$gt: ''}`, operator smuggling) is rejected and reported, same as `findById`/`removeById` reject a plain-object id. `saveAll` delegates to an unordered `insertMany`; non-object entries are dropped silently, and on partial failure (e.g. one entry hits a duplicate key) it resolves to the successfully inserted subset instead of `[]`. Non-object input to `save` and non-array input to `saveAll` are rejected and reported, like every other validation reject.
 
 `count({})` short-circuits to `estimatedDocumentCount`, which reads the cached collection size without a full scan. Numbers may be slightly off on sharded collections with orphans or after an unclean shutdown, but the path is roughly two orders of magnitude faster.
 
-`count(query)` with a non-empty filter calls `countDocuments` and falls back to a streamed `find` cursor with `_id`-only projection when the driver rejects the query (operators such as `$where` and `$near` are valid in `find` but not in the aggregation `$match` that `countDocuments` builds). The fallback streams in batches and is bounded in memory, but it's a real round trip — prefer indexed predicates when possible.
+`count(query)` with a non-empty filter calls `countDocuments` and falls back to a streamed `find` cursor with `_id`-only projection when the driver rejects the query (operators such as `$where` and `$near` are valid in `find` but not in the aggregation `$match` that `countDocuments` builds) — except for `$where` itself (at any depth inside `$and`/`$or`/`$nor`), which never falls back: re-running it via the cursor would execute that JS against every document, so it collapses to `0` like any other rejected query instead. The remaining fallback streams in batches and is bounded in memory, but it's a real round trip — prefer indexed predicates when possible — and is reported via `onError` before it runs, so the cost is observable.
 
 ## Read options
 
@@ -199,7 +216,7 @@ Strings that are not valid 24-character hex pass through unchanged, so numeric a
 
 `findById`/`removeById` reject `null`, `undefined`, and plain-object ids before the driver sees them (reported as `Invalid id rejected`): an operator object like `{ $ne: null }` smuggled from request input would otherwise match — or delete — an arbitrary document. Use `findOne({ _id: { ... } })` for intentional operator queries.
 
-Apart from this id normalization, query objects are passed to the driver **unsanitized** — that is the point of a thin wrapper. Never feed raw request input (`req.body`, `req.query`) into a query position; validate and build the filter yourself.
+Apart from this id normalization, query objects are passed to the driver **unsanitized** — see [Trust boundary](#trust-boundary) for the full picture, including the update-document and read `options`.
 
 ## Observability
 

--- a/test/abort-signal.js
+++ b/test/abort-signal.js
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { describe, test, before, after, beforeEach } from 'node:test';
 
 import { MongoClient } from '../lib/index.js';
+import { SLOW_WHERE } from './helpers.js';
 
 const COLLECTION = `easymongo_abort_${randomUUID()}`;
 
@@ -245,11 +246,6 @@ describe('AbortSignal — caller can detect abort via signal.aborted', () => {
     });
   });
 });
-
-// $where busy-waits per document (mongo evaluates it document-by-document),
-// making the query reliably slower than a small timeout, so the deadline fires.
-const SLOW_WHERE =
-  'var t = Date.now(); while (Date.now() - t < 120) {} return true;';
 
 describe('timeout option — deadline cancels a slow operation', () => {
   test('find collapses to [] when the timeout fires', async () => {

--- a/test/abort-signal.js
+++ b/test/abort-signal.js
@@ -308,6 +308,29 @@ describe('timeout option — composes and stays out of the way', () => {
     });
   });
 
+  test('a live signal and a timeout both armed: either wins, no throw, reported once', async () => {
+    await withClient(async (mongo, captured) => {
+      const col = mongo.collection(COLLECTION);
+      await col.saveAll([{ n: 1 }, { n: 2 }, { n: 3 }]);
+
+      const ctrl = new AbortController();
+      setTimeout(() => ctrl.abort(), 15);
+
+      const result = await col.find(
+        { $where: SLOW_WHERE },
+        { signal: ctrl.signal, timeout: 30 }
+      );
+
+      assert.deepEqual(result, []);
+      assert.equal(
+        captured.length,
+        1,
+        'reported exactly once, not once per mechanism'
+      );
+      assert.equal(captured[0].ctx.method, 'find');
+    });
+  });
+
   test('non-positive timeout is ignored', async () => {
     await withClient(async (mongo) => {
       const col = mongo.collection(COLLECTION);

--- a/test/client.js
+++ b/test/client.js
@@ -16,9 +16,16 @@ test('open/close/open race leaves the second client live', async () => {
   assert.notEqual(mongo.client, null, 'client was clobbered by stale promise');
   assert.notEqual(mongo.db, null, 'db was clobbered by stale promise');
 
-  const after = await users.count();
-  assert.equal(typeof after, 'number');
-  assert.notEqual(mongo.client, null);
+  // close() has now fully settled (awaited above via Promise.allSettled), so
+  // the client is permanently closed: this later, non-racing call must not
+  // silently reconnect - it collapses to the empty default instead.
+  const captured = [];
+  const after = await users.count({}, { onError: (err) => captured.push(err) });
+  assert.equal(after, 0, 'does not reconnect once close() has settled');
+  assert.ok(
+    captured.some((err) => /closed/i.test(err.message)),
+    'reports that the client is closed'
+  );
 
   await mongo.close();
   assert.equal(mongo.client, null);

--- a/test/client.js
+++ b/test/client.js
@@ -117,9 +117,8 @@ test('reopen attempted synchronously after close() is rejected, original client 
 
   const firstClose = mongo.close();
 
-  // _closed is already true here (set synchronously at the top of close(),
-  // before firstClose's teardown I/O even starts), so this must not get a
-  // fresh client - no orphaned pool left behind.
+  // Same synchronous-close invariant as the test above: the reopen must not
+  // get a fresh client before firstClose's teardown I/O even starts.
   const reopen = mongo.collection('easymongo_close_reopen').count();
 
   await Promise.allSettled([firstClose, reopen]);

--- a/test/client.js
+++ b/test/client.js
@@ -3,7 +3,7 @@ import { test } from 'node:test';
 
 import { MongoClient } from '../lib/index.js';
 
-test('open/close/open race leaves the second client live', async () => {
+test('open() called during an in-flight close() is rejected, not given a new pool', async () => {
   const mongo = new MongoClient({ dbname: 'test' }, { silent: true });
   const users = mongo.collection('easymongo_race');
 
@@ -13,19 +13,12 @@ test('open/close/open race leaves the second client live', async () => {
 
   await Promise.allSettled([first, closed, second]);
 
-  assert.notEqual(mongo.client, null, 'client was clobbered by stale promise');
-  assert.notEqual(mongo.db, null, 'db was clobbered by stale promise');
-
-  // close() has now fully settled (awaited above via Promise.allSettled), so
-  // the client is permanently closed: this later, non-racing call must not
-  // silently reconnect - it collapses to the empty default instead.
-  const captured = [];
-  const after = await users.count({}, { onError: (err) => captured.push(err) });
-  assert.equal(after, 0, 'does not reconnect once close() has settled');
-  assert.ok(
-    captured.some((err) => /closed/i.test(err.message)),
-    'reports that the client is closed'
-  );
+  // _closed is set synchronously at the top of close(), before any teardown
+  // I/O - so `second`, called right after, never gets a fresh client that
+  // could outlive this call and go unclosed.
+  assert.equal(mongo.client, null, 'no orphaned pool survives a close() race');
+  assert.equal(mongo.db, null);
+  assert.equal(await second, 0, 'racing open collapses to the empty default');
 
   await mongo.close();
   assert.equal(mongo.client, null);
@@ -110,7 +103,7 @@ test('close(): native close error is swallowed and reported as {method: close}',
   await original();
 });
 
-test('close() racing with reopen closes both clients', async () => {
+test('reopen attempted synchronously after close() is rejected, original client still closes', async () => {
   const mongo = new MongoClient({ dbname: 'test' }, { silent: true });
   await mongo.collection('easymongo_close_reopen').count();
   const clientA = mongo.client;
@@ -124,25 +117,15 @@ test('close() racing with reopen closes both clients', async () => {
 
   const firstClose = mongo.close();
 
-  // Reopen synchronously: open()'s sync prelude installs a fresh native
-  // client on `this.client` before the first await.
+  // _closed is already true here (set synchronously at the top of close(),
+  // before firstClose's teardown I/O even starts), so this must not get a
+  // fresh client - no orphaned pool left behind.
   const reopen = mongo.collection('easymongo_close_reopen').count();
-  const clientB = mongo.client;
-  assert.notEqual(clientA, clientB, 'reopen produced a fresh native client');
 
-  let closeBCalls = 0;
-  const closeB = clientB.close.bind(clientB);
-  clientB.close = async (...args) => {
-    closeBCalls = closeBCalls + 1;
-    return closeB(...args);
-  };
+  await Promise.allSettled([firstClose, reopen]);
 
-  const secondClose = mongo.close();
-
-  await Promise.allSettled([firstClose, reopen, secondClose]);
-
+  assert.equal(await reopen, 0, 'racing reopen collapses to the empty default');
   assert.equal(closeACalls, 1, 'client A closed exactly once');
-  assert.equal(closeBCalls, 1, 'client B closed exactly once');
   assert.equal(mongo.client, null);
   assert.equal(mongo.db, null);
 });

--- a/test/constructor.js
+++ b/test/constructor.js
@@ -51,6 +51,16 @@ test('host is encoded like dbname already is', () => {
   );
 });
 
+test('a bracketed IPv6 literal host keeps its brackets, unencoded', () => {
+  const mongo = new MongoClient({ host: '[::1]', dbname: 'test' });
+  assert.equal(mongo.url, 'mongodb://[::1]:27017/test');
+});
+
+test('a host merely resembling an IPv6 literal is still encoded', () => {
+  const mongo = new MongoClient({ host: '[::1]/evil', dbname: 'test' });
+  assert.equal(mongo.url, 'mongodb://%5B%3A%3A1%5D%2Fevil:27017/test');
+});
+
 test('throws when dbname is missing in object form', () => {
   assert.throws(
     () => new MongoClient({ host: 'localhost' }),

--- a/test/constructor.js
+++ b/test/constructor.js
@@ -40,6 +40,17 @@ test('respects port override', () => {
   assert.equal(mongo.url, 'mongodb://db.example:27018/test');
 });
 
+test('host is encoded like dbname already is', () => {
+  const mongo = new MongoClient({
+    host: 'evil.com/@attacker.example',
+    dbname: 'test'
+  });
+  assert.equal(
+    mongo.url,
+    'mongodb://evil.com%2F%40attacker.example:27017/test'
+  );
+});
+
 test('throws when dbname is missing in object form', () => {
   assert.throws(
     () => new MongoClient({ host: 'localhost' }),

--- a/test/each.js
+++ b/test/each.js
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { describe, test, before, after, beforeEach } from 'node:test';
 
 import { MongoClient } from '../lib/index.js';
+import { SLOW_WHERE } from './helpers.js';
 
 const COLLECTION = `easymongo_each_${randomUUID()}`;
 const mongo = new MongoClient({ dbname: 'test' }, { silent: true });
@@ -114,7 +115,6 @@ describe('each — lifecycle', () => {
       }
     }
     assert.equal(count, 5);
-    // Subsequent operation on the same client must still work.
     assert.equal(await items.count(), 20);
   });
 
@@ -412,10 +412,6 @@ describe('each — AbortSignal', () => {
     await seed(3);
     const captured = [];
 
-    // $where burns >timeout per document server-side, so the deadline armed by
-    // the wrapper fires mid-query.
-    const SLOW_WHERE =
-      'var t = new Date(); while (new Date() - t < 120) {} return true;';
     const out = [];
     for await (const doc of items.each(
       { $where: SLOW_WHERE },
@@ -432,10 +428,6 @@ describe('each — AbortSignal', () => {
     await seed(3);
     const captured = [];
 
-    // $where burns >timeout per document server-side, so whichever mechanism
-    // fires first aborts mid-query - both are live, not one pre-fired.
-    const SLOW_WHERE =
-      'var t = new Date(); while (new Date() - t < 120) {} return true;';
     const ctrl = new AbortController();
     setTimeout(() => ctrl.abort(), 15);
 

--- a/test/each.js
+++ b/test/each.js
@@ -427,4 +427,31 @@ describe('each — AbortSignal', () => {
     assert.deepEqual(out, []);
     assert.deepEqual(captured, ['each']);
   });
+
+  test('a live signal and a timeout both armed: either wins, no throw, reported once', async () => {
+    await seed(3);
+    const captured = [];
+
+    // $where burns >timeout per document server-side, so whichever mechanism
+    // fires first aborts mid-query - both are live, not one pre-fired.
+    const SLOW_WHERE =
+      'var t = new Date(); while (new Date() - t < 120) {} return true;';
+    const ctrl = new AbortController();
+    setTimeout(() => ctrl.abort(), 15);
+
+    const out = [];
+    for await (const doc of items.each(
+      { $where: SLOW_WHERE },
+      {
+        signal: ctrl.signal,
+        timeout: 30,
+        onError: (err, ctx) => captured.push(ctx.method)
+      }
+    )) {
+      out.push(doc);
+    }
+
+    assert.deepEqual(out, []);
+    assert.deepEqual(captured, ['each']);
+  });
 });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,4 @@
+// $where busy-waits per document (mongo evaluates it document-by-document),
+// making the query reliably slower than a small timeout, so the deadline fires.
+export const SLOW_WHERE =
+  'var t = Date.now(); while (Date.now() - t < 120) {} return true;';

--- a/test/index.js
+++ b/test/index.js
@@ -79,23 +79,57 @@ describe('count', () => {
     );
   });
 
-  test('falls back to materialization for $where', async () => {
-    await users.saveAll([
+  test('$where does not trigger the scan fallback; collapses to 0', async () => {
+    const captured = [];
+    const local = new MongoClient(
+      { dbname: 'test' },
+      { onError: (err, ctx) => captured.push({ err, ctx }) }
+    );
+    const col = local.collection(COLLECTION);
+
+    await col.saveAll([
       { name: 'A', age: 20 },
       { name: 'B', age: 35 },
       { name: 'C', age: 40 },
       { name: 'D', age: 25 }
     ]);
+
     // countDocuments rejects $where ($where is disallowed inside its $match
-    // aggregation stage), so the wrapper must fall back to a real query.
-    const n = await users.count({ $where: 'this.age > 30' });
-    assert.equal(n, 2);
+    // aggregation stage). Re-running it via the scan fallback would execute
+    // that JS against every document, so it must collapse to 0 instead of
+    // falling back.
+    const n = await col.count({ $where: 'this.age > 30' });
+    assert.equal(n, 0);
+    assert.equal(captured.length, 1);
+    assert.equal(captured[0].ctx.method, 'count');
+
+    await local.close();
   });
 
-  test('falls back for Location* uassert codes', async (t) => {
-    await users.saveAll([{ a: 1 }, { a: 2 }]);
+  test('nested $where (inside $and/$or) also collapses to 0, no scan', async () => {
+    await users.saveAll([
+      { name: 'A', age: 20 },
+      { name: 'B', age: 35 }
+    ]);
 
-    const native = await mongo.open(COLLECTION);
+    // MongoDB validates $where recursively through logical operators, not
+    // just at the top level - a one-level check would miss this shape.
+    const n = await users.count({
+      $and: [{ name: { $exists: true } }, { $or: [{ $where: 'true' }] }]
+    });
+    assert.equal(n, 0);
+  });
+
+  test('falls back for Location* uassert codes, and reports the fallback', async (t) => {
+    const captured = [];
+    const local = new MongoClient(
+      { dbname: 'test' },
+      { onError: (err, ctx) => captured.push({ err, ctx }) }
+    );
+    const col = local.collection(COLLECTION);
+    await col.saveAll([{ a: 1 }, { a: 2 }]);
+
+    const native = await local.open(COLLECTION);
     t.mock.method(native, 'countDocuments', async () => {
       const err = new Error('synthetic uassert');
       err.name = 'MongoServerError';
@@ -104,7 +138,12 @@ describe('count', () => {
       throw err;
     });
 
-    assert.equal(await users.count({ a: { $gte: 1 } }), 2);
+    assert.equal(await col.count({ a: { $gte: 1 } }), 2);
+    assert.equal(captured.length, 1, 'fallback trigger was reported');
+    assert.equal(captured[0].ctx.method, 'count');
+    assert.match(captured[0].err.message, /fallback/i);
+
+    await local.close();
   });
 
   test('does not fall back to a scan for non-query-shape errors', async (t) => {

--- a/test/index.js
+++ b/test/index.js
@@ -798,21 +798,29 @@ describe('connection lifecycle', () => {
     assert.equal(first, second);
   });
 
-  test('close() then reuse: old Collection wrapper reconnects cleanly', async () => {
-    const client = new MongoClient({ dbname: 'test' }, { silent: true });
-    const col = client.collection(`easymongo_test_${randomUUID()}`);
+  test('close() then reuse: does not reconnect, collapses to the empty default', async () => {
+    const captured = [];
+    const client = new MongoClient(
+      { dbname: 'test' },
+      { onError: (err, ctx) => captured.push({ err, ctx }) }
+    );
+    const name = `easymongo_test_${randomUUID()}`;
+    const col = client.collection(name);
 
     await col.save({ name: 'before' });
     assert.equal(await col.count(), 1);
 
+    // Cleanup must happen before close(): wipe() opens the client directly,
+    // which now throws once the client is permanently closed.
+    await wipe(client, name);
     await client.close();
 
     const found = await col.findOne({ name: 'before' });
-    assert.ok(found);
-    assert.equal(found.name, 'before');
-
-    await wipe(client, col.name);
-    await client.close();
+    assert.equal(found, null);
+    assert.ok(
+      captured.some((c) => /closed/i.test(c.err.message ?? '')),
+      'reports that the client is closed instead of silently reconnecting'
+    );
   });
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -851,7 +851,7 @@ describe('connection lifecycle', () => {
     assert.equal(await col.count(), 1);
 
     // Cleanup must happen before close(): wipe() opens the client directly,
-    // which now throws once the client is permanently closed.
+    // which throws once the client is permanently closed.
     await wipe(client, name);
     await client.close();
 

--- a/test/index.js
+++ b/test/index.js
@@ -177,6 +177,32 @@ describe('count', () => {
     assert.equal(result, 0);
     assert.equal(findCalls, 0, 'find not called for a non-MongoServerError');
   });
+
+  test('hasWhere() safely skips a non-object entry and a duplicate reference inside $and', async (t) => {
+    const native = await mongo.open(COLLECTION);
+    t.mock.method(native, 'countDocuments', async () => {
+      const err = new Error('synthetic uassert');
+      err.name = 'MongoServerError';
+      err.code = 2;
+      err.codeName = 'BadValue';
+      throw err;
+    });
+    t.mock.method(native, 'find', () => ({
+      async *[Symbol.asyncIterator]() {
+        yield { _id: 1 };
+      },
+      close: async () => {}
+    }));
+
+    const shared = { a: 1 };
+    // A non-object array entry and a duplicate object reference both need to
+    // be skipped safely by hasWhere()'s traversal, without crashing or
+    // treating the duplicate as an infinite loop.
+    const result = await users.count({
+      $and: ['not-an-object', shared, shared]
+    });
+    assert.equal(result, 1);
+  });
 });
 
 describe('find', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -844,8 +844,13 @@ describe('saveAll partial recovery', () => {
     ]);
 
     assert.equal(result.length, 2);
-    const names = result.map((d) => d.name).sort();
-    assert.deepEqual(names, ['A', 'B']);
+    // No .sort() here on purpose: recover() preserves input-index order, so
+    // this must hold positionally (A came before the conflict, B after it),
+    // not just as a set.
+    assert.deepEqual(
+      result.map((d) => d.name),
+      ['A', 'B']
+    );
     for (const doc of result) {
       assert.ok(doc._id instanceof ObjectId);
     }

--- a/test/index.js
+++ b/test/index.js
@@ -120,6 +120,20 @@ describe('count', () => {
     assert.equal(n, 0);
   });
 
+  test('$where nested arbitrarily deep still collapses to 0, no scan', async () => {
+    await users.saveAll([{ name: 'A' }, { name: 'B' }]);
+
+    // hasWhere() detects this via an iterative traversal, not a fixed depth
+    // cap - a depth-limited check would treat sufficiently deep nesting as
+    // "safe" and let the vulnerable scan fallback run.
+    let filter = { $where: 'true' };
+    for (let i = 0; i < 20; i = i + 1) {
+      filter = { $and: [filter] };
+    }
+
+    assert.equal(await users.count(filter), 0);
+  });
+
   test('falls back for Location* uassert codes, and reports the fallback', async (t) => {
     const captured = [];
     const local = new MongoClient(

--- a/test/index.js
+++ b/test/index.js
@@ -316,6 +316,23 @@ describe('save', () => {
     t.mock.method(native, 'insertOne', async () => ({}));
     assert.equal(await users.save({ name: 'ghost' }), null);
   });
+
+  test('rejects operator-object _id (operator smuggling)', async () => {
+    const captured = [];
+    const local = new MongoClient(
+      { dbname: 'test' },
+      { onError: (err, ctx) => captured.push({ err, ctx }) }
+    );
+    const col = local.collection(COLLECTION);
+
+    const result = await col.save({ _id: { $gt: '' }, secret: 'ATTACKER' });
+    assert.equal(result, null);
+    assert.equal(await col.count(), 0);
+    assert.equal(captured.length, 1);
+    assert.equal(captured[0].ctx.method, 'save');
+
+    await local.close();
+  });
 });
 
 describe('saveAll', () => {
@@ -355,6 +372,31 @@ describe('saveAll', () => {
     assert.equal(result.length, 2);
     const pinned = result.find((d) => d.name === 'pinned');
     assert.equal(pinned._id, id);
+  });
+
+  test('operator-object _id entries are dropped and reported, others still inserted', async () => {
+    const captured = [];
+    const local = new MongoClient(
+      { dbname: 'test' },
+      { onError: (err, ctx) => captured.push({ err, ctx }) }
+    );
+    const col = local.collection(COLLECTION);
+
+    const result = await col.saveAll([
+      { name: 'A' },
+      { _id: { $gt: '' }, name: 'attacker' },
+      { name: 'B' }
+    ]);
+
+    assert.equal(result.length, 2);
+    assert.deepEqual(
+      result.map((d) => d.name),
+      ['A', 'B']
+    );
+    assert.equal(captured.length, 1);
+    assert.equal(captured[0].ctx.method, 'saveAll');
+
+    await local.close();
   });
 });
 

--- a/test/indexes.js
+++ b/test/indexes.js
@@ -218,8 +218,8 @@ describe('ensureIndexes', () => {
     await col.createIndex({ slug: 1 }, { unique: true });
 
     const names = await col.ensureIndexes([
-      { key: { slug: 1 }, options: { unique: false } }, // conflicts → skip
-      { key: { kind: 1 } } // ok → created
+      { key: { slug: 1 }, options: { unique: false } },
+      { key: { kind: 1 } }
     ]);
 
     assert.equal(names.length, 1);
@@ -271,7 +271,7 @@ describe('ensureIndexes', () => {
 
   test('skips entries without a key', async () => {
     const names = await items.ensureIndexes([
-      { options: { unique: true } }, // no key → skip
+      { options: { unique: true } },
       null,
       { key: { city: 1 } }
     ]);

--- a/test/observability.js
+++ b/test/observability.js
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
 import { test } from 'node:test';
 
 import { MongoClient } from '../lib/index.js';
@@ -103,6 +104,28 @@ test('default output: console.error is called when neither silent nor onError ar
 
   assert.ok(calls.length >= 1);
   assert.match(String(calls[0][0]), /\[easymongo\] users\.find failed:/);
+
+  await mongo.close();
+});
+
+test('default output: a driver error can carry a field value even though ctx.query is never printed', async (t) => {
+  const calls = [];
+  t.mock.method(console, 'error', (...args) => calls.push(args));
+
+  const mongo = new MongoClient({ dbname: 'test' });
+  const users = mongo.collection(`easymongo_pii_${randomUUID()}`);
+  await users.createIndex({ email: 1 }, { unique: true });
+
+  await users.save({ email: 'alice@secret-domain.example' });
+  await users.save({ email: 'alice@secret-domain.example' }); // duplicate key
+
+  assert.ok(calls.length >= 1);
+  const printed = String(calls[0][1]);
+  assert.match(
+    printed,
+    /alice@secret-domain\.example/,
+    'the driver error itself carries the field value - the default logger never prints ctx.query, but does print err'
+  );
 
   await mongo.close();
 });

--- a/test/trust-boundary.js
+++ b/test/trust-boundary.js
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { describe, test, before, after, beforeEach } from 'node:test';
+
+import { MongoClient } from '../lib/index.js';
+
+// These tests pin currently-intentional, documented behavior: this is a thin
+// wrapper, not a sanitizing layer. Only the by-id scalar slot (findById /
+// removeById) is guarded; everything below is expected to stay open. A
+// future refactor that narrows or widens any of these surfaces should have
+// to touch a failing test here, on purpose - not drift silently.
+
+const COLLECTION = `easymongo_trust_${randomUUID()}`;
+const mongo = new MongoClient({ dbname: 'test' }, { silent: true });
+const users = mongo.collection(COLLECTION);
+
+async function wipe() {
+  const native = await mongo.open(COLLECTION);
+  await native.deleteMany({});
+}
+
+before(wipe);
+after(async () => {
+  await wipe();
+  await mongo.close();
+});
+beforeEach(wipe);
+
+describe('trust boundary — filter injection is open (except by-id)', () => {
+  test('findOne: an operator in a filter field bypasses the intended match', async () => {
+    await users.save({ user: 'admin', pw: 'correcthorsebatterystaple' });
+
+    const result = await users.findOne({ pw: { $ne: '__nope__' } });
+    assert.ok(result);
+    assert.equal(result.user, 'admin');
+  });
+
+  test('find: an operator in a filter field matches everything', async () => {
+    await users.saveAll([{ n: 1 }, { n: 2 }, { n: 3 }]);
+
+    const result = await users.find({ n: { $ne: -1 } });
+    assert.equal(result.length, 3);
+  });
+
+  test('update: an operator in the filter reaches every document', async () => {
+    await users.saveAll([{ n: 1 }, { n: 2 }]);
+
+    const changed = await users.update(
+      { n: { $ne: -1 } },
+      { $set: { touched: true } }
+    );
+    assert.equal(changed, true);
+    assert.equal(await users.count({ touched: true }), 2);
+  });
+
+  test('remove: an operator in the filter deletes everything', async () => {
+    await users.saveAll([{ n: 1 }, { n: 2 }, { n: 3 }]);
+
+    const removed = await users.remove({ n: { $ne: -1 } });
+    assert.equal(removed, true);
+    assert.equal(await users.count(), 0);
+  });
+
+  test('each(): the streaming path is injectable the same way as find()', async () => {
+    await users.saveAll([{ owner: 'a' }, { owner: 'b' }, { owner: 'c' }]);
+
+    const seen = [];
+    for await (const doc of users.each({ owner: { $ne: '__nope__' } })) {
+      seen.push(doc.owner);
+    }
+    assert.equal(seen.length, 3);
+  });
+
+  test('findById/removeById reject the same operator shape in the id slot', async () => {
+    await users.save({ name: 'Alexey' });
+
+    assert.equal(await users.findById({ $ne: null }), null);
+    assert.equal(await users.removeById({ $ne: null }), false);
+    assert.equal(await users.count(), 1, 'nothing was matched or removed');
+  });
+});
+
+describe('trust boundary — the update-document is not validated', () => {
+  test('an untrusted $set/$inc payload applies as-is (mass assignment)', async () => {
+    const created = await users.save({ role: 'user', balance: 0 });
+
+    const untrustedUpdate = {
+      $set: { role: 'admin' },
+      $inc: { balance: 999999 }
+    };
+    const changed = await users.update({ _id: created._id }, untrustedUpdate);
+
+    assert.equal(changed, true);
+    const found = await users.findById(created._id);
+    assert.equal(found.role, 'admin');
+    assert.equal(found.balance, 999999);
+  });
+});
+
+describe('trust boundary — options.fields/projection expose whatever is asked', () => {
+  test('fields: picking a real sensitive field is not blocked', async () => {
+    await users.save({ name: 'Alexey', password: 'S3CRET-HASH' });
+
+    const result = await users.findOne(
+      { name: 'Alexey' },
+      { fields: ['password'] }
+    );
+    assert.ok(result);
+    assert.equal(result.password, 'S3CRET-HASH');
+  });
+
+  test('projection: same story via the native driver shape', async () => {
+    await users.save({ name: 'Alexey', password: 'S3CRET-HASH' });
+
+    const result = await users.findOne(
+      { name: 'Alexey' },
+      { projection: { password: 1 } }
+    );
+    assert.ok(result);
+    assert.equal(result.password, 'S3CRET-HASH');
+  });
+
+  test('the fail-closed whitelist collapse only guards the degenerate case, not field choice', async () => {
+    await users.save({ name: 'Alexey', password: 'S3CRET-HASH' });
+
+    // A caller-supplied array that resolves to no usable fields collapses to
+    // {_id: 1} (can't disable the whitelist) - but a real field name, even a
+    // sensitive one, is a valid whitelist entry and passes straight through.
+    const degenerate = await users.findOne(
+      { name: 'Alexey' },
+      { fields: ['__proto__'] }
+    );
+    assert.equal(degenerate.password, undefined);
+
+    const chosen = await users.findOne(
+      { name: 'Alexey' },
+      { fields: ['password'] }
+    );
+    assert.equal(chosen.password, 'S3CRET-HASH');
+  });
+});


### PR DESCRIPTION
- `close()` now permanently closes the client. A later operation no longer silently reopens a new connection pool — it collapses to its own empty default and is reported, same as any other swallowed error.

### Hardening (against hostile / unvalidated input)

- `count()` no longer re-executes `$where` (top-level or nested via `$and`/`$or`/`$nor`) through its scan fallback — collapses to `0` instead of running the query's JS against every document. The remaining fallback (e.g. unsupported geo operators) is now reported via `onError` before it scans.
- `save` and `saveAll` reject a plain-object `_id` (operator smuggling), same guard as `findById`/`removeById`.
- `host`/`port` are now `encodeURIComponent`-encoded when building the connection URL, like `dbname` already was.
